### PR TITLE
Support for `a` and `an`

### DIFF
--- a/src/parsers/EN/ENDeadlineFormatParser.js
+++ b/src/parsers/EN/ENDeadlineFormatParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(within|in)\s*([0-9]+)\s*(minutes?|hours?|days?)\s*(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(within|in)\s*([0-9]+|an?)\s*(minutes?|hours?|days?)\s*(?=(?:\W|$))/i;
 
 exports.Parser = function ENDeadlineFormatParser(){
     Parser.call(this);
@@ -27,7 +27,11 @@ exports.Parser = function ENDeadlineFormatParser(){
         });
 
         var num = match[3];
-        num = parseInt(num);
+        if (num === 'a' || num === 'an'){
+            num = 1;
+        } else {
+            num = parseInt(num);
+        }
 
         var date = moment(ref);
         if (match[4].match(/day/)) {

--- a/src/parsers/EN/ENTimeAgoFormatParser.js
+++ b/src/parsers/EN/ENTimeAgoFormatParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(?:within\s*)?([0-9]+)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
 
 exports.Parser = function ENTimeAgoFormatParser(){
     Parser.call(this);
@@ -29,8 +29,12 @@ exports.Parser = function ENTimeAgoFormatParser(){
         });
 
         var num = match[2];
-        num = parseInt(num);
-
+        if(num === 'a' || num === 'an'){
+            num = 1;
+        } else {
+            num = parseInt(num);
+        }
+        
         var date = moment(ref);
         if (match[3].match(/day/)) {
 

--- a/src/parsers/EN/ENTimeAgoFormatParser.js
+++ b/src/parsers/EN/ENTimeAgoFormatParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(?:within|in\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
 
 exports.Parser = function ENTimeAgoFormatParser(){
     Parser.call(this);

--- a/src/parsers/EN/ENTimeAgoFormatParser.js
+++ b/src/parsers/EN/ENTimeAgoFormatParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(?:within|in\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
 
 exports.Parser = function ENTimeAgoFormatParser(){
     Parser.call(this);


### PR DESCRIPTION
Something I did through the web interface, so hopefully it works (I didn't have time to test it, more of a concept).

Should think of `a` and `an` as 1