### PR TITLE
Check for 'a.m.'/'p.m.' does not work

### DIFF
--- a/src/parsers/EN/ENTimeExpressionParser.js
+++ b/src/parsers/EN/ENTimeExpressionParser.js
@@ -104,12 +104,13 @@ exports.Parser = function ENTimeExpressionParser(){
         // ----- AM & PM  
         if(match[AM_PM_HOUR_GROUP] != null) {
             if(hour > 12) return null;
-            if(match[AM_PM_HOUR_GROUP].replace(".", "").toLowerCase() == "am"){
+            var ampm = match[AM_PM_HOUR_GROUP].replace(/\./g, "").toLowerCase();
+            if(ampm == "am"){
                 meridiem = 0; 
                 if(hour == 12) hour = 0;
             }
             
-            if(match[AM_PM_HOUR_GROUP].replace(".", "").toLowerCase() == "pm"){
+            if(ampm == "pm"){
                 meridiem = 1; 
                 if(hour != 12) hour += 12;
             }

--- a/test-qunit/test_en_time_exp.js
+++ b/test-qunit/test_en_time_exp.js
@@ -71,6 +71,26 @@ test("Test - Single Expression", function() {
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
 
+    var text = "5:16 p.m.";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if(result){
+        ok(result.index == 0, 'Wrong index')
+        ok(result.text == '5:16 p.m.', result.text )
+
+        ok(result.start, JSON.stringify(result.start) )
+        ok(result.start.get('hour') == 17, 'Test Result - (Day) ' + JSON.stringify(result.start) )
+        ok(result.start.get('minute') == 16, 'Test Result - (Day) ' + JSON.stringify(result.start) )
+        ok(!result.start.isCertain('second'))
+        ok(!result.start.isCertain('millisecond'))
+
+
+      var resultDate = result.start.date();
+        var expectDate = new Date(2012, 7, 10, 17, 16);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
 
     var text = "Lets meet at 6.13 AM";
     var results = chrono.parse(text, new Date(2012,7,10));


### PR DESCRIPTION
String.replace only replaces the first occurrence of a string, yielding 'am.'. Change to a regex so we can do a replace all.