### PR TITLE
Only imply tomorrow as today 1 hour after midnight

### DIFF
--- a/src/parsers/EN/ENCasualDateParser.js
+++ b/src/parsers/EN/ENCasualDateParser.js
@@ -1,6 +1,6 @@
 /*
-    
-    
+
+
 */
 
 var moment = require('moment');
@@ -8,15 +8,15 @@ var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
 var PATTERN = /(\W|^)(today|tonight|tomorrow|tmr|yesterday|last\s*night|this\s*(morning|afternoon|evening))(?=\W|$)/i;
-    
+
 exports.Parser = function ENCasualDateParser(){
-    
+
     Parser.apply(this, arguments);
-        
+
     this.pattern = function() { return PATTERN; }
-    
-    this.extract = function(text, ref, match, opt){ 
-        
+
+    this.extract = function(text, ref, match, opt){
+
         var text = match[0].substr(match[1].length);
         var index = match.index + match[1].length;
         var result = new ParsedResult({
@@ -30,14 +30,14 @@ exports.Parser = function ENCasualDateParser(){
         var lowerText = text.toLowerCase();
 
         if(lowerText == 'tonight'){
-            // Normally means this coming midnight 
+            // Normally means this coming midnight
             result.start.imply('hour', 22);
             result.start.imply('meridiem', 1);
 
         } else if(lowerText == 'tomorrow' || lowerText == 'tmr'){
 
             // Check not "Tomorrow" on late night
-            if(refMoment.hour() > 4) {
+            if(refMoment.hour() > 1) {
                 startMoment.add(1, 'day');
             }
 
@@ -76,4 +76,3 @@ exports.Parser = function ENCasualDateParser(){
         return result;
     }
 }
-


### PR DESCRIPTION
This makes it so `tomorrow` is only pared as `today` one hour after midnight - not the previous 4.

Related to #83 