### PR TITLE
Add parsing for seconds

### DIFF
--- a/src/parsers/EN/ENDeadlineFormatParser.js
+++ b/src/parsers/EN/ENDeadlineFormatParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(within|in)\s*([0-9]+|an?|half(?:\s*an?)?)\s*(minutes?|hours?|days?)\s*(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(within|in)\s*([0-9]+|an?|half(?:\s*an?)?)\s*(seconds?|minutes?|hours?|days?)\s*(?=(?:\W|$))/i;
 
 exports.Parser = function ENDeadlineFormatParser(){
     Parser.apply(this, arguments);
@@ -53,6 +53,10 @@ exports.Parser = function ENDeadlineFormatParser(){
         } else if (match[4].match(/minute/)) {
 
             date.add(num, 'minute');
+
+        } else if (match[4].match(/second/)) {
+
+            date.add(num, 'second');
         }
 
         result.start.imply('year', date.year());
@@ -60,6 +64,7 @@ exports.Parser = function ENDeadlineFormatParser(){
         result.start.imply('day', date.date());
         result.start.assign('hour', date.hour());
         result.start.assign('minute', date.minute());
+        result.start.assign('second', date.second());
         result.tags['ENDeadlineFormatParser'] = true;
         return result;
     };

--- a/src/parsers/EN/ENTimeAgoFormatParser.js
+++ b/src/parsers/EN/ENTimeAgoFormatParser.js
@@ -7,8 +7,8 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?|half(?:\s*an?)?)\s*(minutes?|hours?|weeks?|days?|months?|years?)\s*(?:ago|before|earlier)(?=(?:\W|$))/i;
-var STRICT_PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?)\s*(minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
+var PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?|half(?:\s*an?)?)\s*(seconds?|minutes?|hours?|weeks?|days?|months?|years?)\s*(?:ago|before|earlier)(?=(?:\W|$))/i;
+var STRICT_PATTERN = /(\W|^)(?:within\s*)?([0-9]+|an?)\s*(seconds?|minutes?|hours?|days?)\s*ago(?=(?:\W|$))/i;
 
 exports.Parser = function ENTimeAgoFormatParser(){
     Parser.apply(this, arguments);
@@ -42,7 +42,7 @@ exports.Parser = function ENTimeAgoFormatParser(){
 
         var date = moment(ref);
 
-        if (match[3].match(/hour/) || match[3].match(/minute/)) {
+        if (match[3].match(/hour|minute|second/)) {
             if (match[3].match(/hour/)) {
 
                 date.add(-num, 'hour');
@@ -50,6 +50,10 @@ exports.Parser = function ENTimeAgoFormatParser(){
             } else if (match[3].match(/minute/)) {
 
                 date.add(-num, 'minute');
+
+            } else if (match[3].match(/second/)) {
+
+                date.add(-num, 'second');
             }
 
             result.start.imply('day', date.date());
@@ -57,6 +61,7 @@ exports.Parser = function ENTimeAgoFormatParser(){
             result.start.imply('year', date.year());
             result.start.assign('hour', date.hour());
             result.start.assign('minute', date.minute());
+            result.start.assign('second', date.second());
             result.tags['ENTimeAgoFormatParser'] = true;
             return result;
         }


### PR DESCRIPTION
This adds the ability to parse for seconds in English “time ago” and “deadline” formats.

It just follows the same pattern as minutes/hours; nothing novel.

Tests all still pass.