### PR TITLE
Added capability to parse AD/BC in year (English, French, Spanish)

### DIFF
--- a/src/parsers/EN/ENMonthNameLittleEndianParser.js
+++ b/src/parsers/EN/ENMonthNameLittleEndianParser.js
@@ -16,8 +16,8 @@ var PATTERN = new RegExp('(\\W|^)' +
         '(?:\\s*(?:to|\\-|\\–|until|through|till|\\s)\\s*([0-9]{1,2})(?:st|nd|rd|th)?)?\\s*(?:of)?\\s*' +
         '(Jan(?:uary|\\.)?|Feb(?:ruary|\\.)?|Mar(?:ch|\\.)?|Apr(?:il|\\.)?|May|Jun(?:e|\\.)?|Jul(?:y|\\.)?|Aug(?:ust|\\.)?|Sep(?:tember|\\.)?|Oct(?:ober|\\.)?|Nov(?:ember|\\.)?|Dec(?:ember|\\.)?)' +
         '(?:' +
-            ',?\\s*([0-9]{2,4}(?![^\\s]\\d))' +
-            '(\\s*BE)?' +
+            ',?\\s*([0-9]{1,4}(?![^\\s]\\d))' +
+            '(\\s*(?:BE|AD|BC))?' +
         ')?' +
         '(?=\\W|$)', 'i'
     );
@@ -54,8 +54,19 @@ exports.Parser = function ENMonthNameLittleEndianParser(){
             year = parseInt(year);
 
             if(match[YEAR_BE_GROUP]){
-                //BC
-                year = year - 543;
+
+                if (/BE/i.test(match[YEAR_BE_GROUP])) {
+                    // Buddhist Era
+                    year = year - 543;
+                } else if (/BC/i.test(match[YEAR_BE_GROUP])) {
+                    // Before Christ
+                    year = -year;
+                }
+
+            } else if (year < 10) {
+
+                // require single digit years to always have BC/AD
+                return null;
 
             } else if (year < 100){
 

--- a/src/parsers/EN/ENMonthNameMiddleEndianParser.js
+++ b/src/parsers/EN/ENMonthNameMiddleEndianParser.js
@@ -33,7 +33,7 @@ var PATTERN = new RegExp('(\\W|^)' +
         '([0-9]{1,2})(?:st|nd|rd|th)?\\s*' +
     ')?' +
     '(?:' +
-        '\\s*,?\\s*([0-9]{4})(\\s*BE)?\\s*' +
+        '\\s*,?\\s*(?:([0-9]{4})\\s*(BE|AD|BC)?|([0-9]{1,4})\\s*(AD|BC))\\s*' +
     ')?' +
     '(?=\\W|$)(?!\\:\\d)', 'i');
 
@@ -43,6 +43,8 @@ var DATE_GROUP = 4;
 var DATE_TO_GROUP = 5;
 var YEAR_GROUP = 6;
 var YEAR_BE_GROUP = 7;
+var YEAR_GROUP2 = 8;
+var YEAR_BE_GROUP2 = 9;
 
 exports.Parser = function ENMonthNameMiddleEndianParser(){
     Parser.apply(this, arguments);
@@ -69,14 +71,19 @@ exports.Parser = function ENMonthNameMiddleEndianParser(){
         day = parseInt(day);
 
         var year = null;
-        if (match[YEAR_GROUP]) {
-            year = match[YEAR_GROUP];
+        if (match[YEAR_GROUP] || match[YEAR_GROUP2]) {
+            year = match[YEAR_GROUP] || match[YEAR_GROUP2];
             year = parseInt(year);
 
-            if(match[YEAR_BE_GROUP]){
-                //BC
-                year = year - 543;
-
+            var yearBE = match[YEAR_BE_GROUP] || match[YEAR_BE_GROUP2];
+            if (yearBE) {
+                if (/BE/i.test(yearBE)) {
+                    // Buddhist Era
+                    year = year - 543;
+                } else if (/BC/i.test(yearBE)) {
+                    // Before Christ
+                    year = -year;
+                }
             } else if (year < 100){
 
                 year = year + 2000;

--- a/src/parsers/EN/ENMonthNameParser.js
+++ b/src/parsers/EN/ENMonthNameParser.js
@@ -18,7 +18,7 @@ var PATTERN = new RegExp('(^|\\D\\s+|[^\\w\\s])' +
     '(Jan\\.?|January|Feb\\.?|February|Mar\\.?|March|Apr\\.?|April|May\\.?|Jun\\.?|June|Jul\\.?|July|Aug\\.?|August|Sep\\.?|Sept\\.?|September|Oct\\.?|October|Nov\\.?|November|Dec\\.?|December)' + 
     '\\s*' +
     '(?:' +
-        ',?\\s*([0-9]{4})(\\s*BE)?' +
+        ',?\\s*([0-9]{4})(\\s*BE|AD|BC)?' +
     ')?' +
     '(?=[^\\s\\w]|$)', 'i');
 
@@ -49,9 +49,14 @@ exports.Parser = function ENMonthNameParser(){
             year = match[YEAR_GROUP];
             year = parseInt(year);
 
-            if(match[YEAR_BE_GROUP]){ 
-                //BC
-                year = year - 543;
+            if(match[YEAR_BE_GROUP]){
+                if (match[YEAR_BE_GROUP].match(/BE/)) {
+                    // Buddhist Era
+                    year = year - 543;
+                } else if (match[YEAR_BE_GROUP].match(/BC/)) {
+                    // Before Christ
+                    year = -year;
+                }
 
             } else if (year < 100){ 
 
@@ -88,4 +93,3 @@ exports.Parser = function ENMonthNameParser(){
         return result;
     }
 }
-

--- a/src/parsers/EN/ENTimeExpressionParser.js
+++ b/src/parsers/EN/ENTimeExpressionParser.js
@@ -194,7 +194,8 @@ exports.Parser = function ENTimeExpressionParser(){
 
             if (hour > 12) return null;
 
-            if(match[AM_PM_HOUR_GROUP][0].toLowerCase() == "a"){
+            var ampm = match[AM_PM_HOUR_GROUP][0].toLowerCase();
+            if(ampm == "a"){
                 meridiem = 0; 
                 if(hour == 12) {
                     hour = 0;
@@ -204,7 +205,7 @@ exports.Parser = function ENTimeExpressionParser(){
                 }
             }
             
-            if(match[AM_PM_HOUR_GROUP][0].toLowerCase() == "p"){
+            if(ampm == "p"){
                 meridiem = 1; 
                 if(hour != 12) hour += 12;
             }
@@ -252,4 +253,3 @@ exports.Parser = function ENTimeExpressionParser(){
         return result;
     }
 }
-

--- a/src/parsers/ES/ESMonthNameLittleEndianParser.js
+++ b/src/parsers/ES/ESMonthNameLittleEndianParser.js
@@ -17,7 +17,7 @@ var PATTERN = new RegExp('(\\W|^)' +
         '([0-9]{1,2})(?:º|ª|°)?' +
         '(?:\\s*(?:desde|de|\\-|\\–|al?|hasta|\\s)\\s*([0-9]{1,2})(?:º|ª|°)?)?\\s*(?:de)?\\s*' +
         '(Ene(?:ro|\\.)?|Feb(?:rero|\\.)?|Mar(?:zo|\\.)?|Abr(?:il|\\.)?|May(?:o|\\.)?|Jun(?:io|\\.)?|Jul(?:io|\\.)?|Ago(?:sto|\\.)?|Sep(?:tiembre|\\.)?|Oct(?:ubre|\\.)?|Nov(?:iembre|\\.)?|Dic(?:iembre|\\.)?)' +
-        '(?:\\s*(?:del?)?(\\s*[0-9]{2,4}(?![^\\s]\\d))(\\s*AC)?)?' +
+        '(?:\\s*(?:del?)?(\\s*[0-9]{1,4}(?![^\\s]\\d))(\\s*[ad]\\.?\\s*c\\.?|a\\.?\\s*d\\.?)?)?' +
         '(?=\\W|$)', 'i'
     );
 
@@ -53,9 +53,10 @@ exports.Parser = function ESMonthNameLittleEndianParser(){
             year = parseInt(year);
 
             if(match[YEAR_BE_GROUP]){
-                //BC
-                year = year - 543;
-
+                if (/a\.?\s*c\.?/i.test(match[YEAR_BE_GROUP])) {
+                    // antes de Cristo
+                    year = -year;
+                }
             } else if (year < 100){
 
                 year = year + 2000;

--- a/src/parsers/ES/ESSlashDateFormatParser.js
+++ b/src/parsers/ES/ESSlashDateFormatParser.js
@@ -93,9 +93,9 @@ exports.Parser = function ESSlashDateFormatParser(argument) {
 
         if(year < 100){
             if(year > 50){
-                year = year + 2500 - 543; //BE
+                year = year + 1900;
             }else{
-                year = year + 2000; //AD
+                year = year + 2000;
             }
         }
 

--- a/src/parsers/FR/FRMonthNameLittleEndianParser.js
+++ b/src/parsers/FR/FRMonthNameLittleEndianParser.js
@@ -17,7 +17,7 @@ var PATTERN = new RegExp('(\\W|^)' +
         '([0-9]{1,2})' +
         '(?:\\s*(?:au|\\-|\\–|jusqu\'au?|\\s)\\s*([0-9]{1,2})(?:er)?)?\\s*(?:de)?\\s*' +
         '(Jan(?:vier|\\.)?|Fév(?:rier|\\.)?|Mars|Avr(?:il|\\.)?|Mai|Juin|Juil(?:let|\\.)?|Ao[uû]t|Sept(?:embre|\\.)?|Oct(?:obre|\\.)?|Nov(?:embre|\\.)?|déc(?:embre|\\.)?)' +
-        '(?:\\s*(\\s*[0-9]{2,4}(?![^\\s]\\d))(\\s*AC)?)?' +
+        '(?:\\s*(\\s*[0-9]{1,4}(?![^\\s]\\d))(?:\\s*(AC|[ap]\\.?\\s*c(?:h(?:r)?)?\\.?\\s*n\\.?))?)?' +
         '(?=\\W|$)', 'i'
     );
 
@@ -53,9 +53,10 @@ exports.Parser = function FRMonthNameLittleEndianParser(){
             year = parseInt(year);
 
             if(match[YEAR_BE_GROUP]){
-                //BC
-                year = year - 543;
-
+                if (/a/i.test(match[YEAR_BE_GROUP])) {
+                    // Ante Christe natum
+                    year = -year;
+                }
             } else if (year < 100){
 
                 year = year + 2000;

--- a/src/parsers/FR/FRSlashDateFormatParser.js
+++ b/src/parsers/FR/FRSlashDateFormatParser.js
@@ -92,9 +92,9 @@ exports.Parser = function FRSlashDateFormatParser(argument) {
 
         if(year < 100){
             if(year > 50){
-                year = year + 2500 - 543; //BE
+                year = year + 1900;
             }else{
-                year = year + 2000; //AD
+                year = year + 2000;
             }
         }
 

--- a/test/test_en_little_endian.js
+++ b/test/test_en_little_endian.js
@@ -41,6 +41,45 @@ test("Test - Single expression", function() {
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
 
+    var text = "10 August 234 BC";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) );
+
+    var result = results[0];
+    if (result) {
+        ok(result.index == 0, 'Wrong index');
+        ok(result.text == '10 August 234 BC', result.text );
+
+        ok(result.start, JSON.stringify(result.start) );
+        ok(result.start.get('year') == -234, 'Test Result - (Year) ' + JSON.stringify(result.start) );
+        ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) );
+        ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) );
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(-234, 8-1, 10, 12);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
+    var text = "10 August 88 AD";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) );
+
+    var result = results[0];
+    if (result) {
+        ok(result.index == 0, 'Wrong index');
+        ok(result.text == '10 August 88 AD', result.text );
+
+        ok(result.start, JSON.stringify(result.start) );
+        ok(result.start.get('year') == 88, 'Test Result - (Year) ' + JSON.stringify(result.start) );
+        ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) );
+        ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) );
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(88, 8-1, 10, 12);
+        expectDate.setFullYear(88);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
     var text = 'Sun 15Sep';
     var results = chrono.parse(text, new Date(2013,7,10));
     ok(results.length == 1, JSON.stringify( results ) );
@@ -411,5 +450,4 @@ test("Test - Impossible Dates (Casual Mode)", function() {
     ok(results.length == 1, JSON.stringify(results) );
     ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 1000, resultDate +'/' +expectDate);
 });
-
 

--- a/test/test_en_middle_endian.js
+++ b/test/test_en_middle_endian.js
@@ -130,6 +130,35 @@ test("Test - Single Expression", function() {
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
 
+    var text = "The Deadline is August 10, 345 BC";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if(result){
+        ok(result.index == 16, 'Wrong index')
+        ok(result.text == 'August 10, 345 BC', result.text )
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(-345, 8-1, 10, 12);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
+    var text = "The Deadline is August 10, 8 AD";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if(result){
+        ok(result.index == 16, 'Wrong index')
+        ok(result.text == 'August 10, 8 AD', result.text )
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(8, 8-1, 10, 12);
+        expectDate.setFullYear(8);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
     var text = 'The Deadline is Tuesday, January 10';
     var results = chrono.parse(text, new Date(2012,7,10));
     ok(results.length == 1, JSON.stringify( results ) )

--- a/test/test_es_little_endian.js
+++ b/test/test_es_little_endian.js
@@ -21,24 +21,46 @@ test("Test - Single expression", function() {
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
 
-    var text = "10 Agosto 2555 AC";
+    var text = "10 Agosto 234 AC";
     var results = chrono.parse(text, new Date(2012,7,10));
     ok(results.length == 1, JSON.stringify( results ) )
 
     var result = results[0];
     if (result) {
         ok(result.index == 0, 'Wrong index')
-        ok(result.text == '10 Agosto 2555 AC', result.text )
+        ok(result.text == '10 Agosto 234 AC', result.text )
 
         ok(result.start, JSON.stringify(result.start) )
-        ok(result.start.get('year') == 2012, 'Test Result - (Year) ' + JSON.stringify(result.start) )
+        ok(result.start.get('year') == -234, 'Test Result - (Year) ' + JSON.stringify(result.start) )
         ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) )
         ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) )
 
         var resultDate = result.start.date();
-        var expectDate = new Date(2012, 8-1, 10, 12);
+        var expectDate = new Date(-234, 8-1, 10, 12);
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
+
+
+    var text = "10 Agosto 88 d. C.";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if (result) {
+        ok(result.index == 0, 'Wrong index')
+        ok(result.text == '10 Agosto 88 d. C.', result.text )
+
+        ok(result.start, JSON.stringify(result.start) )
+        ok(result.start.get('year') == 88, 'Test Result - (Year) ' + JSON.stringify(result.start) )
+        ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) )
+        ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) )
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(88, 8-1, 10, 12);
+        expectDate.setFullYear(88);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
 
     var text = 'Dom 15Sep';
     var results = chrono.parse(text, new Date(2013,7,10));

--- a/test/test_fr_little_endian.js
+++ b/test/test_fr_little_endian.js
@@ -21,6 +21,48 @@ test("Test - Single expression", function() {
         ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
     }
 
+
+    var text = "10 Août 234 AC";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if (result) {
+        ok(result.index == 0, 'Wrong index')
+        ok(result.text == '10 Août 234 AC', result.text )
+
+        ok(result.start, JSON.stringify(result.start) )
+        ok(result.start.get('year') == -234, 'Test Result - (Year) ' + JSON.stringify(result.start) )
+        ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) )
+        ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) )
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(-234, 8-1, 10, 12);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
+
+    var text = "10 Août 88 p. Chr. n.";
+    var results = chrono.parse(text, new Date(2012,7,10));
+    ok(results.length == 1, JSON.stringify( results ) )
+
+    var result = results[0];
+    if (result) {
+        ok(result.index == 0, 'Wrong index')
+        ok(result.text == '10 Août 88 p. Chr. n.', result.text )
+
+        ok(result.start, JSON.stringify(result.start) )
+        ok(result.start.get('year') == 88, 'Test Result - (Year) ' + JSON.stringify(result.start) )
+        ok(result.start.get('month') == 8, 'Test Result - (Month) ' + JSON.stringify(result.start) )
+        ok(result.start.get('day') == 10, 'Test Result - (Day) ' + JSON.stringify(result.start) )
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(88, 8-1, 10, 12);
+        expectDate.setFullYear(88);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate +'/' +expectDate)
+    }
+
+
     var text = 'Dim 15 Sept';
     var results = chrono.parse(text, new Date(2013,7,10));
     ok(results.length == 1, JSON.stringify( results ) );
@@ -368,5 +410,4 @@ test("Test - Impossible Dates (Casual Mode)", function() {
     ok(results.length == 1, JSON.stringify(results) );
     ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 1000, resultDate +'/' +expectDate);
 });
-
 


### PR DESCRIPTION
In the French and Spanish translations the "BE" (= Buddhist Era) (after the year number) in English was misinterpreted to mean "BC" (= Before Christ). Added and corrected support for "BC" / "AD" in English, French, Spanish.

In French, the abbreviations
- AC
- a. C. n., a. Chr. n.
- p. C. n., p. Chr. n.
are accepted. The fullstops are optional. The abbreviations are not case sensitive.

In Spanish, the abbreviations
- a. C.
- a.d.
- d. C.
are accepted. The fullstops are optional. The abbreviations are not case sensitive.