### PR TITLE
Separate "morning" "afternoon" etc logic

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -78,6 +78,7 @@ exports.casualOption = function () {
 
     // EN
     options.parsers.unshift(new parser.ENCasualDateParser());
+    options.parsers.unshift(new parser.ENCasualTimeParser());
     options.parsers.unshift(new parser.ENWeekdayParser());
     options.parsers.unshift(new parser.ENRelativeDateFormatParser());
 
@@ -91,6 +92,6 @@ exports.casualOption = function () {
     // FR
     options.parsers.unshift(new parser.FRCasualDateParser());
     options.parsers.unshift(new parser.FRWeekdayParser());
-    
+
     return options;
 };

--- a/src/parsers/EN/ENCasualDateParser.js
+++ b/src/parsers/EN/ENCasualDateParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)(now|today|tonight|last\s*night|(?:this|tomorrow|tmr|yesterday)\s*(morning|afternoon|evening)|tomorrow|tmr|yesterday)(?=\W|$)/i;
+var PATTERN = /(\W|^)(now|today|tonight|last\s*night|(?:tomorrow|tmr|yesterday)\s*|tomorrow|tmr|yesterday)(?=\W|$)/i;
 
 exports.Parser = function ENCasualDateParser(){
 
@@ -59,22 +59,6 @@ exports.Parser = function ENCasualDateParser(){
           result.start.imply('second', refMoment.second());
           result.start.imply('millisecond', refMoment.millisecond());
 
-        }
-
-        if (match[3]) {
-            var secondMatch = match[3].toLowerCase();
-            if (secondMatch == "afternoon") {
-
-                result.start.imply('hour', 15);
-
-            } else if (secondMatch == "evening") {
-
-                result.start.imply('hour', 18);
-
-            } else if (secondMatch == "morning") {
-
-                result.start.imply('hour', 6);
-            }
         }
 
         result.start.assign('day', startMoment.date())

--- a/src/parsers/EN/ENCasualTimeParser.js
+++ b/src/parsers/EN/ENCasualTimeParser.js
@@ -1,0 +1,49 @@
+/*
+
+
+*/
+
+var moment = require('moment');
+var Parser = require('../parser').Parser;
+var ParsedResult = require('../../result').ParsedResult;
+
+var PATTERN = /(\W|^)((this)?\s*(morning|afternoon|evening))/i;
+
+var TIME_MATCH = 4;
+
+exports.Parser = function ENCasualTimeParser(){
+
+    Parser.apply(this, arguments);
+
+
+    this.pattern = function() { return PATTERN; }
+
+    this.extract = function(text, ref, match, opt){
+
+        var text = match[0].substr(match[1].length);
+        var index = match.index + match[1].length;
+        var result = new ParsedResult({
+            index: index,
+            text: text,
+            ref: ref,
+        });
+
+        if(!match[TIME_MATCH]) TIME_MATCH = 3;
+
+        if (match[TIME_MATCH] == "afternoon") {
+
+            result.start.imply('hour', 15);
+
+        } else if (match[TIME_MATCH] == "evening") {
+
+            result.start.imply('hour', 18);
+
+        } else if (match[TIME_MATCH] == "morning") {
+
+            result.start.imply('hour', 6);
+        }
+
+        result.tags['ENCasualTimeParser'] = true;
+        return result;
+    };
+};

--- a/src/parsers/EN/ENCasualTimeParser.js
+++ b/src/parsers/EN/ENCasualTimeParser.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
-var PATTERN = /(\W|^)((this)?\s*(morning|afternoon|evening))/i;
+var PATTERN = /(\W|^)((this)?\s*(morning|afternoon|evening|noon))/i;
 
 var TIME_MATCH = 4;
 
@@ -32,15 +32,19 @@ exports.Parser = function ENCasualTimeParser(){
 
         if (match[TIME_MATCH] == "afternoon") {
 
-            result.start.imply('hour', 15);
+            result.start.imply('hour', opt['afternoon'] ? opt['afternoon'] : 15);
 
         } else if (match[TIME_MATCH] == "evening") {
 
-            result.start.imply('hour', 18);
+            result.start.imply('hour', opt['evening'] ? opt['evening'] : 18);
 
         } else if (match[TIME_MATCH] == "morning") {
 
-            result.start.imply('hour', 6);
+            result.start.imply('hour', opt['morning'] ? opt['morning'] : 6);
+
+        } else if (match[TIME_MATCH] == "noon") {
+
+            result.start.imply('hour', opt['noon'] ? opt['noon'] : 12);
         }
 
         result.tags['ENCasualTimeParser'] = true;

--- a/src/parsers/parser.js
+++ b/src/parsers/parser.js
@@ -63,6 +63,7 @@ exports.ENTimeAgoFormatParser = require('./EN/ENTimeAgoFormatParser').Parser;
 exports.ENTimeExpressionParser = require('./EN/ENTimeExpressionParser').Parser;
 exports.ENWeekdayParser = require('./EN/ENWeekdayParser').Parser;
 exports.ENCasualDateParser = require('./EN/ENCasualDateParser').Parser;
+exports.ENCasualTimeParser = require('./EN/ENCasualTimeParser').Parser;
 
 exports.JPStandardParser = require('./JP/JPStandardParser').Parser;
 exports.JPCasualDateParser = require('./JP/JPCasualDateParser').Parser;

--- a/test/test_en_weekday.js
+++ b/test/test_en_weekday.js
@@ -176,6 +176,27 @@ test("Test - Single Expression", function () {
     }
 });
 
+test("Test - Weekday With Casual Time", function () {
+    var text = "Lets meet on Tuesday morning";
+    var results = chrono.casual.parse(text, new Date(2015, 3, 18));
+    ok(results.length == 1, JSON.stringify(results));
+    var result = results[0];
+    if (result) {
+        ok(result.index == 10, 'Wrong index');
+        ok(result.text == 'on Tuesday morning', result.text);
+
+        ok(result.start, JSON.stringify(result.start));
+        ok(result.start.get('year') == 2015, 'Test Result - (Year) ' + JSON.stringify(result.start));
+        ok(result.start.get('month') == 4, 'Test Result - (Month) ' + JSON.stringify(result.start));
+        ok(result.start.get('day') == 21, 'Test Result - (Day) ' + JSON.stringify(result.start));
+        ok(result.start.get('weekday') == 2, 'Test Result - (Weekday) ' + JSON.stringify(result.start));
+        ok(result.start.get('hour') == 6, 'Test Result - (Hour) ' + JSON.stringify(result.start));
+
+        var resultDate = result.start.date();
+        var expectDate = new Date(2015, 3, 21, 6);
+        ok(Math.abs(expectDate.getTime() - resultDate.getTime()) < 100000, 'Test result.startDate ' + resultDate + '/' + expectDate)
+    }
+});
 
 test("Test - Weekday Overlap", function () {
 


### PR DESCRIPTION
I found that with the current set up we were able to only do things like "tomorrow morning" or "yesterday afterrnoon" but things like "monday morning" or specific dates with "morning" would not work. 

My suggested solution was to create a casual time parser only for those terms like "morning", "afternoon", etc. We can add more later like "lunch time" "sunset" etc etc

Test passed 100% and I created a test for the day of the week and casual time.

Let me know your thoughts.