### PR TITLE
ENDeadlineFormatParser should have implied rather than known Date values

### DIFF
--- a/src/parsers/EN/ENDeadlineFormatParser.js
+++ b/src/parsers/EN/ENDeadlineFormatParser.js
@@ -67,9 +67,9 @@ exports.Parser = function ENDeadlineFormatParser(){
                 date.add(num, 'year');
             }
 
-            result.start.assign('year', date.year());
-            result.start.assign('month', date.month() + 1);
-            result.start.assign('day', date.date());
+            result.start.imply('year', date.year());
+            result.start.imply('month', date.month() + 1);
+            result.start.imply('day', date.date());
             return result;
         }
 
@@ -89,9 +89,9 @@ exports.Parser = function ENDeadlineFormatParser(){
         result.start.imply('year', date.year());
         result.start.imply('month', date.month() + 1);
         result.start.imply('day', date.date());
-        result.start.assign('hour', date.hour());
-        result.start.assign('minute', date.minute());
-        result.start.assign('second', date.second());
+        result.start.imply('hour', date.hour());
+        result.start.imply('minute', date.minute());
+        result.start.imply('second', date.second());
         result.tags['ENDeadlineFormatParser'] = true;
         return result;
     };

--- a/test/test_en_deadline.js
+++ b/test/test_en_deadline.js
@@ -309,3 +309,69 @@ test("Test - Single Expression (Strict)", function() {
     var results = chrono.strict.parse(text, new Date(2012, 8-1, 3));
     ok(results.length == 0, JSON.stringify( results ) )
 });
+
+
+test("Test - Single Expression (Implied)", function() {
+
+    var text = "within 30 days";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+    var text = "within 30 months";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+    var text = "within 30 years";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+    var text = "within 5 hours";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+    var text = "within 5 minutes";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+    var text = "within 5 seconds";
+    var results = chrono.parse(text, new Date(2012,7,10,12,14));
+    ok(results.length == 1, JSON.stringify( results ) );
+    ok(!results[0].start.isCertain('year'), 'Test Result - (Year) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('month'), 'Test Result - (Month) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('day'), 'Test Result - (Day) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('hour'), 'Test Result - (Hour) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('minute'), 'Test Result - (Minute) ' + JSON.stringify(results[0].start));
+    ok(!results[0].start.isCertain('second'), 'Test Result - (Second) ' + JSON.stringify(results[0].start));
+
+});
+


### PR DESCRIPTION
Currently when a date in Deadline format is parsed it results in a series of known values:
``` 
{  
   "ref":"2017-07-25T23:11:17.234Z",
   "index":246,
   "text":"within 30 days",
   "tags":{  

   },
   "start":{  
      "knownValues":{  
         "year":2017,
         "month":8,
         "day":24
      },
      "impliedValues":{  
         "hour":12,
         "minute":0,
         "second":0,
         "millisecond":0
      }
   }
}
```

Since all the values from this parser are based on the Reference Date, I think it's important to indicate that these are all implied, rather than known.

As far as a use-case goes; I'm currently leveraging this project with historical documents where a reference date can not always be determined. To ensure I don't provide incorrect data, any date which has an implied year/month are removed. Since 'Within 30 days' is being parsed as Today + 30 days, but not indicating that the values are implied, I'm left manually removing these instances.

The changes consist of altering all 'assign' methods to 'imply' from the Deadline parser, and a set of tests around it. Only done to EN, I can apply similar changes to DE/ES/FR/ZHHant if desired.