### PR TITLE
Fixed missing var declaration which was throwing.

### DIFF
--- a/src/parsers/EN/ENTimeAgoFormatParser.js
+++ b/src/parsers/EN/ENTimeAgoFormatParser.js
@@ -28,7 +28,7 @@ exports.Parser = function ENTimeAgoFormatParser(){
 
         var text = match[0];
         text  = match[0].substr(match[1].length, match[0].length - match[1].length);
-        index = match.index + match[1].length;
+        var index = match.index + match[1].length;
 
         var result = new ParsedResult({
             index: index,


### PR DESCRIPTION
For some reason this was only throwing when my project was being bundled with Webpack, not sure if that's relevant or not.  Maybe because "use strict" is added to the bundle?

Regardless it appears to be a bug as index isn't explicitly declared.