### PR TITLE
Loosen moment dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "coveralls": "npm run test && cat coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "moment": "2.21.0"
+    "moment": "^2.21.0"
   }
 }


### PR DESCRIPTION
Loosen the moment dependency so that downstream libraries can choose which version of moment to use.

Currently, consumers are forced to use `moment@2.21.0` if they use `chrono-node`, even if they're already using a more recent version. This causes moment, which uses a stateful singleton for things like the default locale, to load and initialize more than once. 