### PR TITLE
Implement 令和('reiwa' Japanese era) (2019〜) and 元年(the 1st year of the year)

### DIFF
--- a/src/parsers/ja/JPStandardParser.js
+++ b/src/parsers/ja/JPStandardParser.js
@@ -9,7 +9,7 @@ var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
 var util  = require('../../utils/JP'); 
-var PATTERN = /(?:(同|((昭和|平成)?([0-9０-９]{2,4})))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i;
+var PATTERN = /(?:(同|((昭和|平成|令和)?([0-9０-９]{2,4}|元)))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i;
   
 var YEAR_GROUP        = 2;
 var ERA_GROUP         = 3;
@@ -67,10 +67,16 @@ exports.Parser = function JPStandardParser(){
 
         } else {
             var year = match[YEAR_NUMBER_GROUP];
-            year = util.toHankaku(year);
-            year = parseInt(year);
+            if (year == '元') {
+                year = 1;
+            } else {
+                year = util.toHankaku(year);
+                year = parseInt(year);
+            }
 
-            if (match[ERA_GROUP] == '平成') {
+            if (match[ERA_GROUP] == '令和') {
+                year += 2018;
+            } else if (match[ERA_GROUP] == '平成') {
                 year += 1988;
             } else if (match[ERA_GROUP] == '昭和') {
                 year += 1925;

--- a/test/ja/ja_standard.test.js
+++ b/test/ja/ja_standard.test.js
@@ -99,7 +99,24 @@ test("Test - Single Expression", function() {
         expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
     } 
 
-    
+    var text = "主な株主（令和元年5月1日）";
+    var results = chrono.parse(text, new Date(2012,8-1,10));
+    expect(results.length).toBe(1)
+
+    var result = results[0];
+    if (result) {
+        expect(result.index).toBe(5)
+        expect(result.text).toBe('令和元年5月1日')
+
+        expect(result.start).not.toBeNull()
+        expect(result.start.get('year')).toBe(2019)
+        expect(result.start.get('month')).toBe(5)
+        expect(result.start.get('day')).toBe(1)
+        
+        var resultDate = result.start.date();
+        var expectDate = new Date(2019, 5-1, 1, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
+    }
 });
 
 


### PR DESCRIPTION

![440px-Yoshihide_Suga_announcing_new_imperial_era_Reiwa_2_(cropped)](https://user-images.githubusercontent.com/6166778/61994740-73380400-b0b9-11e9-8a26-474f1223f01d.jpg)


Japanese emperor Akihito has retired on April 30th, 2019, and 令和 (reiwa) era has stared on May 1st, 2019.
In Japan, the 1st year of Reiwa is called "令和元年"(Reiwa-gannen) and never called "令和1年".
So now (2019-07-27) is called "令和元年7月27日"
https://en.wikipedia.org/wiki/Reiwa


I'd like to make the new era name "令和" and the form of era's 1st year "元年" parseable with chrono.