### PR TITLE
JP parser: 同年|今年|本年 patterns are not captured correctly

### DIFF
--- a/src/parsers/ja/JPStandardParser.js
+++ b/src/parsers/ja/JPStandardParser.js
@@ -11,11 +11,12 @@ var ParsedResult = require('../../result').ParsedResult;
 var util  = require('../../utils/JP'); 
 var PATTERN = /(?:(同|今|本|((昭和|平成|令和)?([0-9０-９]{2,4}|元)))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i;
   
-var YEAR_GROUP        = 2;
-var ERA_GROUP         = 3;
-var YEAR_NUMBER_GROUP = 4;
-var MONTH_GROUP       = 5;
-var DAY_GROUP         = 6;
+var YEAR_GROUP          = 1;
+var ABSOLUTE_YEAR_GROUP = 2; // not used
+var ERA_GROUP           = 3;
+var YEAR_NUMBER_GROUP   = 4;
+var MONTH_GROUP         = 5;
+var DAY_GROUP           = 6;
 
 exports.Parser = function JPStandardParser(){
     Parser.apply(this, arguments);
@@ -61,7 +62,7 @@ exports.Parser = function JPStandardParser(){
             result.start.assign('month', startMoment.month() + 1);
             result.start.imply('year', startMoment.year());
 
-        } else if (match[YEAR_GROUP].match('同年|今年|本年')) {
+        } else if (match[YEAR_GROUP].match('同|今|本')) {
 
             result.start.assign('year', startMoment.year());
 

--- a/test/ja/ja_standard.test.js
+++ b/test/ja/ja_standard.test.js
@@ -71,7 +71,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('平成26年12月29日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(2014)
+        expect(result.start.knownValues.year).toBe(2014)
         expect(result.start.get('month')).toBe(12)
         expect(result.start.get('day')).toBe(29)
         
@@ -90,7 +90,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('昭和６４年１月７日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(1989)
+        expect(result.start.knownValues.year).toBe(1989)
         expect(result.start.get('month')).toBe(1)
         expect(result.start.get('day')).toBe(7)
         
@@ -110,7 +110,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('令和元年5月1日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(2019)
+        expect(result.start.knownValues.year).toBe(2019)
         expect(result.start.get('month')).toBe(5)
         expect(result.start.get('day')).toBe(1)
         
@@ -128,7 +128,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('同年7月27日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(2012)
+        expect(result.start.knownValues.year).toBe(2012)
         expect(result.start.get('month')).toBe(7)
         expect(result.start.get('day')).toBe(27)
 
@@ -147,7 +147,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('本年7月27日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(2012)
+        expect(result.start.knownValues.year).toBe(2012)
         expect(result.start.get('month')).toBe(7)
         expect(result.start.get('day')).toBe(27)
 
@@ -166,7 +166,7 @@ test("Test - Single Expression", function() {
         expect(result.text).toBe('今年7月27日')
 
         expect(result.start).not.toBeNull()
-        expect(result.start.get('year')).toBe(2012)
+        expect(result.start.knownValues.year).toBe(2012)
         expect(result.start.get('month')).toBe(7)
         expect(result.start.get('day')).toBe(27)
 


### PR DESCRIPTION
The regexp pattern for `同年|今年|本年` is not implemented correctly.
`同年|今年|本年` should be captured with the index `1` of the pattern ` /(?:(同|今|本|((昭和|平成|令和)?([0-9０-９]{2,4}|元)))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i`
```
1: (同|今|本|((昭和|平成|令和)?([0-9０-９]{2,4}|元)))
2: ((昭和|平成|令和)?([0-9０-９]{2,4}|元))
3: (昭和|平成|令和)
4: ([0-9０-９]{2,4}|元)
5: ([0-9０-９]{1,2})
6: ([0-9０-９]{1,2})
```

Currently, chrono implies the year to the same year of refDate by default, but chrono should return the year as a knownValue if the document says `同年|今年|本年`.