### PR TITLE
JP parser: Capture era year with 1 digit like '令和2年'

### DIFF
--- a/src/parsers/ja/JPStandardParser.js
+++ b/src/parsers/ja/JPStandardParser.js
@@ -9,7 +9,7 @@ var Parser = require('../parser').Parser;
 var ParsedResult = require('../../result').ParsedResult;
 
 var util  = require('../../utils/JP'); 
-var PATTERN = /(?:(同|今|本|((昭和|平成|令和)?([0-9０-９]{2,4}|元)))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i;
+var PATTERN = /(?:(同|今|本|((昭和|平成|令和)?([0-9０-９]{1,4}|元)))年\s*)?([0-9０-９]{1,2})月\s*([0-9０-９]{1,2})日/i;
   
 var YEAR_GROUP        = 2;
 var ERA_GROUP         = 3;

--- a/test/ja/ja_standard.test.js
+++ b/test/ja/ja_standard.test.js
@@ -118,6 +118,26 @@ test("Test - Single Expression", function() {
         var expectDate = new Date(2019, 5-1, 1, 12);
         expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
     }
+
+    var text = "主な株主（令和2年5月1日）";
+    var results = chrono.parse(text, new Date(2012,8-1,10));
+    expect(results.length).toBe(1)
+
+    var result = results[0];
+    if (result) {
+        expect(result.index).toBe(5)
+        expect(result.text).toBe('令和2年5月1日')
+
+        expect(result.start).not.toBeNull()
+        expect(result.start.knownValues.year).toBe(2020)
+        expect(result.start.get('month')).toBe(5)
+        expect(result.start.get('day')).toBe(1)
+        
+        var resultDate = result.start.date();
+        var expectDate = new Date(2020, 5-1, 1, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
+    }
+
     var text = "主な株主（同年7月27日）";
     var results = chrono.parse(text, new Date(2012,8-1,10));
     expect(results.length).toBe(1)


### PR DESCRIPTION
To enter the new year 2020 (令和2年), we need this.

I think this does not break the accuracy because the parser parse the 1-digit year part like `1年` only if the year part is next to `m月n日`.
