### PR TITLE
JpParser: Fixed parsing Feb 29th  leap year while current year is not a leap year.

### DIFF
--- a/src/parsers/ja/JPStandardParser.js
+++ b/src/parsers/ja/JPStandardParser.js
@@ -31,19 +31,6 @@ exports.Parser = function JPStandardParser(){
             ref: ref,
         });
         
-        var month = match[MONTH_GROUP];
-        month = util.toHankaku(month);
-        month = parseInt(month);
-
-        var day = match[DAY_GROUP];
-        day = util.toHankaku(day);
-        day = parseInt(day);
-
-        startMoment.set('date', day);
-        startMoment.set('month', month - 1);
-        result.start.assign('day', startMoment.date());
-        result.start.assign('month', startMoment.month() + 1);
-            
         if (!match[YEAR_GROUP]) {
             
             //Find the most appropriated year
@@ -57,8 +44,6 @@ exports.Parser = function JPStandardParser(){
                 startMoment = lastYear;
             }
 
-            result.start.assign('day', startMoment.date());
-            result.start.assign('month', startMoment.month() + 1);
             result.start.imply('year', startMoment.year());
 
         } else if (match[YEAR_GROUP].match('同年|今年|本年')) {
@@ -84,6 +69,17 @@ exports.Parser = function JPStandardParser(){
 
             result.start.assign('year', year);
         }
+
+        var month = match[MONTH_GROUP];
+        month = util.toHankaku(month);
+        month = parseInt(month);
+
+        var day = match[DAY_GROUP];
+        day = util.toHankaku(day);
+        day = parseInt(day);
+
+        result.start.assign('month', month);
+        result.start.assign('day', day);
         
 
         result.tags['JPStandardParser'] = true;

--- a/test/ja/ja_standard.test.js
+++ b/test/ja/ja_standard.test.js
@@ -42,6 +42,25 @@ test("Test - Single Expression", function() {
         expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
     } 
 
+    var text = "主な株主（2020年2月29日現在）";
+    var results = chrono.parse(text, new Date(2019,8-1,10));
+    expect(results.length).toBe(1)
+
+    var result = results[0];
+    if (result) {
+        expect(result.index).toBe(5)
+        expect(result.text).toBe('2020年2月29日')
+
+        expect(result.start).not.toBeNull()
+        expect(result.start.get('year')).toBe(2020)
+        expect(result.start.get('month')).toBe(2)
+        expect(result.start.get('day')).toBe(29)
+        
+        var resultDate = result.start.date();
+        var expectDate = new Date(2020, 2-1, 29, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime())
+    } 
+
     var text = "主な株主（９月3日現在）";
     var results = chrono.parse(text, new Date(2012,8-1,10));
     expect(results.length).toBe(1)


### PR DESCRIPTION
When parsing '2020年2月29日' at this time (2019-12-17), chrono returns '2020-02-28'.
This is due to the order of registering 'year, month, day' to the `moment` object.

Month & day parts should be registered AFTER year part.
If month & day parts are registered BEFORE year part, 

- chrono tries to make '2019-02-29' `moment` object in the middle of making '2020-02-29'
- `moment` fall back to '2019-02-28' since '2019-02-29' is an invalid date
- then, chrono registers year part and returns '2020-02-28'

I also did some refactorings, that involve this issue.