### PR TITLE
Update package.json to reflect GitHub repo transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "chrono-node",
   "description": "A natural language date parser in Javascript",
-  "homepage": "http://github.com/berryboy/chrono",
+  "homepage": "http://github.com/wanasit/chrono",
   "repository": {
     "type": "git",
-    "url": "https://github.com/berryboy/chrono.git"
+    "url": "https://github.com/wanasit/chrono.git"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
`berryboy` -> `wanasit`

Will make the npm page display this repo. Yes, it redirects but it's nicer to just be right in the first place, also allows searching NPM by repo as there are a few similarly named libraries on there.