### PR TITLE
Fix for XX-YY dates not being parsed as dates

### DIFF
--- a/src/common/parsers/SlashDateFormatParser.ts
+++ b/src/common/parsers/SlashDateFormatParser.ts
@@ -4,9 +4,10 @@ import dayjs from "dayjs";
 import { findMostLikelyADYear, findYearClosestToRef } from "../../calculation/years";
 
 /**
- * Date format with slash "/" (or dot ".") between numbers.
- * For examples:
+ * Date format with slash "/", dash "-", or dot "." between numbers.
+ * For example:
  * - 7/10
+ * - 7-10
  * - 7/12/2020
  * - 7.12.2020
  */
@@ -59,9 +60,9 @@ export default class SlashDateFormatParser implements Parser {
             return;
         }
 
-        // MM/dd -> OK
+        // MM/dd or MM-dd -> OK
         // MM.dd -> NG
-        if (!match[YEAR_GROUP] && match[0].indexOf("/") < 0) {
+        if (!match[YEAR_GROUP] && !/[/\-]/.test(text)) {
             return;
         }
 

--- a/test/en/en_slash.test.ts
+++ b/test/en/en_slash.test.ts
@@ -77,6 +77,24 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
     });
 
+    testSingleCase(chrono, "8-10", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.end).toBeNull();
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8-10");
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+
     testSingleCase(chrono, "The Deadline is 8/10/2012", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(16);
         expect(result.text).toBe("8/10/2012");
@@ -156,6 +174,25 @@ test("Test - Range Expression", function () {
         expect(result.end.get("day")).toBe(15);
 
         expect(result.end).toBeDate(new Date(2012, 8 - 1, 15, 12));
+    });
+
+    testSingleCase(chrono.en, "2-1 - 2-2", new Date(2012, 1, 1), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("2-1 - 2-2");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(2);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start).toBeDate(new Date(2012, 2 - 1, 1, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(2);
+        expect(result.end.get("day")).toBe(2);
+
+        expect(result.end).toBeDate(new Date(2012, 2 - 1, 2, 12));
     });
 });
 


### PR DESCRIPTION
Currently, dates in the MM-DD format are falling through the `SlashDateFormatParser` and are being incorrectly parsed as time strings by one of the time parsers later in the chain.