### PR TITLE
Fix time unit within using for

### DIFF
--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -6,7 +6,7 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 export default class ENTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return new RegExp(
-            `(?:within|in)\\s*(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?` +
+            `(?:within|in|for)\\s*(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?` +
                 "(" +
                 TIME_UNITS_PATTERN +
                 ")" +

--- a/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
@@ -5,7 +5,7 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 
 export default class FRTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
-        return new RegExp(`(?:dans|en)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
+        return new RegExp(`(?:dans|en|pour|pendant)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {

--- a/test/en/en_time_units_within.test.ts
+++ b/test/en/en_time_units_within.test.ts
@@ -45,6 +45,13 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
+    testSingleCase(chrono, "wait for 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(5);
+        expect(result.text).toBe("for 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
     testSingleCase(chrono, "within 1 hour", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("within 1 hour");

--- a/test/fr/fr_time_units_within.test.ts
+++ b/test/fr/fr_time_units_within.test.ts
@@ -39,6 +39,13 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
+    testSingleCase(chrono.fr, "pour 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("pour 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
     testSingleCase(chrono.fr, "en 1 heure", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("en 1 heure");


### PR DESCRIPTION
Support texts like "set a timer for 5 minutes" or "wait for 1 hour". 