### PR TITLE
Fix parsing of "May" using ENMonthNameParser

### DIFF
--- a/src/locales/en/parsers/ENMonthNameParser.ts
+++ b/src/locales/en/parsers/ENMonthNameParser.ts
@@ -30,7 +30,7 @@ export default class ENMonthNameParser extends AbstractParserWithWordBoundaryChe
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
-        if (match[0].length <= 3) {
+        if (match[0].length <= 3 && !MONTH_DICTIONARY[match[0].toLowerCase()]) {
             return null;
         }
 


### PR DESCRIPTION
Matched string of length 3 and less was discarded, so that string `"May"` was not parsed correctly.