### PR TITLE
Bump dayjs & typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "prettier": "^2.0.5",
     "ts-jest": "^26.1.1",
-    "typescript": "^3.9.6"
+    "typescript": "^4.1.3"
   },
   "husky": {
     "hooks": {
@@ -52,7 +52,7 @@
     "coveralls": "npm run test && cat coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "dayjs": "^1.8.29"
+    "dayjs": "^1.10.0"
   },
   "eslintConfig": {
     "env": {

--- a/test/en/en_relative.test.ts
+++ b/test/en/en_relative.test.ts
@@ -149,12 +149,14 @@ test("Test - Relative date components' certainty", () => {
     });
 
     testSingleCase(chrono, "next month", refDate, (result, text) => {
+        const expectedDate = new Date(2016, 11, 7, 12);
+
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(11);
         expect(result.start.get("day")).toBe(7);
         expect(result.start.get("hour")).toBe(12);
-        expect(result.start.get("timezoneOffset")).toBe(refDate.getTimezoneOffset() * -1);
+        expect(result.start.get("timezoneOffset")).toBe(-expectedDate.getTimezoneOffset());
 
         expect(result.start.isCertain("year")).toBe(true);
         expect(result.start.isCertain("month")).toBe(true);


### PR DESCRIPTION
Bonus: Fix fragile test dealing with time zone offset. Sweden still have summer/winter time.