### PR TITLE
Make "in|within|for" optional if forwardDate=true

### DIFF
--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -4,9 +4,11 @@ import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
 export default class ENTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
-    innerPattern(): RegExp {
+    innerPattern(context: ParsingContext): RegExp {
+        const prefix = context.option.forwardDate ? "" : "(?:within|in|for)\\s*";
         return new RegExp(
-            `(?:within|in|for)\\s*(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?` +
+            prefix +
+                `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?` +
                 "(" +
                 TIME_UNITS_PATTERN +
                 ")" +

--- a/test/en/en_time_units_within.test.ts
+++ b/test/en/en_time_units_within.test.ts
@@ -311,4 +311,19 @@ test("Test - Time units' certainty", () => {
         expect(result.start.isCertain("hour")).toBeFalsy();
         expect(result.start.isCertain("minute")).toBeFalsy();
     });
+
+    testSingleCase(chrono, "give it 2 months", new Date(2016, 10 - 1, 1, 14, 52), { forwardDate: true }, (result) => {
+        expect(result.text).toBe("2 months");
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(52);
+
+        expect(result.start.isCertain("year")).toBeTruthy();
+        expect(result.start.isCertain("month")).toBeTruthy();
+        expect(result.start.isCertain("day")).toBeFalsy();
+        expect(result.start.isCertain("hour")).toBeFalsy();
+        expect(result.start.isCertain("minute")).toBeFalsy();
+    });
 });


### PR DESCRIPTION
This let's us parse expressions like "give it 2 months" given that
forwardDate is set to true. At the same time if forwardDate is not set,
parsing fails as ambiguous.

Fixes #371 
