### PR TITLE
Fixed and extend NL locale + add test for all

### DIFF
--- a/src/common/parsers/ISOFormatParser.ts
+++ b/src/common/parsers/ISOFormatParser.ts
@@ -11,11 +11,11 @@ import { AbstractParserWithWordBoundaryChecking } from "./AbstractParserWithWord
 // - TZD = (Z or +hh:mm or -hh:mm)
 const PATTERN = new RegExp(
     "([0-9]{4})\\-([0-9]{1,2})\\-([0-9]{1,2})" +
-    "(?:T" + //..
-    "([0-9]{1,2}):([0-9]{1,2})" + // hh:mm
-    "(?::([0-9]{1,2})(?:\\.(\\d{1,4}))?)?" + // :ss.s
-    "(?:Z|([+-]\\d{2}):?(\\d{2})?)?" + // TZD (Z or ±hh:mm or ±hhmm or ±hh)
-    ")?" + //..
+        "(?:T" + //..
+        "([0-9]{1,2}):([0-9]{1,2})" + // hh:mm
+        "(?::([0-9]{1,2})(?:\\.(\\d{1,4}))?)?" + // :ss.s
+        "(?:Z|([+-]\\d{2}):?(\\d{2})?)?" + // TZD (Z or ±hh:mm or ±hhmm or ±hh)
+        ")?" + //..
         "(?=\\W|$)",
     "i"
 );

--- a/src/locales/nl/constants.ts
+++ b/src/locales/nl/constants.ts
@@ -213,7 +213,7 @@ const SINGLE_TIME_UNIT_REGEX = new RegExp(SINGLE_TIME_UNIT_PATTERN, "i");
 const SINGLE_TIME_UNIT_PATTERN_NO_CAPTURE = SINGLE_TIME_UNIT_PATTERN.replace(/\((?!\?)/g, "(?:");
 
 export const TIME_UNITS_PATTERN =
-    `(?:(?:about|around)\\s*)?` +
+    `(?:(?:binnen|in)\\s*)?` +
     `${SINGLE_TIME_UNIT_PATTERN_NO_CAPTURE}\\s*(?:,?\\s*${SINGLE_TIME_UNIT_PATTERN_NO_CAPTURE})*`;
 
 export function parseTimeUnits(timeunitText): TimeUnits {

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -13,6 +13,7 @@ import NLMonthNameParser from "./parsers/NLMonthNameParser";
 import NLSlashMonthFormatParser from "./parsers/NLSlashMonthFormatParser";
 import NLTimeExpressionParser from "./parsers/NLTimeExpressionParser";
 import NLCasualYearMonthDayParser from "./parsers/NLCasualYearMonthDayParser";
+import NLCasualDateTimeParser from "./parsers/NLCasualDateTimeParser";
 
 // Shortcuts
 export const casual = new Chrono(createCasualConfiguration());
@@ -30,6 +31,7 @@ export function createCasualConfiguration(littleEndian = true): Configuration {
     const option = createConfiguration(false, littleEndian);
     option.parsers.unshift(new NLCasualDateParser());
     option.parsers.unshift(new NLCasualTimeParser());
+    option.parsers.unshift(new NLCasualDateTimeParser());
     return option;
 }
 

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -44,7 +44,7 @@ export function createConfiguration(strictMode = true, littleEndian = true): Con
                 new NLTimeUnitWithinFormatParser(),
                 new NLSlashMonthFormatParser(),
                 new NLWeekdayParser(),
-                new NLCasualYearMonthDayParser()
+                new NLCasualYearMonthDayParser(),
             ],
             refiners: [new NLMergeDateTimeRefiner(), new NLMergeDateRangeRefiner()],
         },

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -37,12 +37,12 @@ export function createConfiguration(strictMode = true, littleEndian = true): Con
         {
             parsers: [
                 new SlashDateFormatParser(littleEndian),
-                new NLTimeUnitWithinFormatParser(),
-                new NLTimeExpressionParser(),
-                new NLWeekdayParser(),
                 new NLMonthNameMiddleEndianParser(),
                 new NLMonthNameParser(),
+                new NLTimeExpressionParser(),
+                new NLTimeUnitWithinFormatParser(),
                 new NLSlashMonthFormatParser(),
+                new NLWeekdayParser(),
             ],
             refiners: [new NLMergeDateTimeRefiner(), new NLMergeDateRangeRefiner()],
         },

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -11,6 +11,7 @@ import NLWeekdayParser from "./parsers/NLWeekdayParser";
 import NLMonthNameMiddleEndianParser from "./parsers/NLMonthNameMiddleEndianParser";
 import NLMonthNameParser from "./parsers/NLMonthNameParser";
 import NLSlashMonthFormatParser from "./parsers/NLSlashMonthFormatParser";
+import NLTimeExpressionParser from "./parsers/NLTimeExpressionParser";
 
 // Shortcuts
 export const casual = new Chrono(createCasualConfiguration());
@@ -37,6 +38,7 @@ export function createConfiguration(strictMode = true, littleEndian = true): Con
             parsers: [
                 new SlashDateFormatParser(littleEndian),
                 new NLTimeUnitWithinFormatParser(),
+                new NLTimeExpressionParser(),
                 new NLWeekdayParser(),
                 new NLMonthNameMiddleEndianParser(),
                 new NLMonthNameParser(),

--- a/src/locales/nl/index.ts
+++ b/src/locales/nl/index.ts
@@ -12,6 +12,7 @@ import NLMonthNameMiddleEndianParser from "./parsers/NLMonthNameMiddleEndianPars
 import NLMonthNameParser from "./parsers/NLMonthNameParser";
 import NLSlashMonthFormatParser from "./parsers/NLSlashMonthFormatParser";
 import NLTimeExpressionParser from "./parsers/NLTimeExpressionParser";
+import NLCasualYearMonthDayParser from "./parsers/NLCasualYearMonthDayParser";
 
 // Shortcuts
 export const casual = new Chrono(createCasualConfiguration());
@@ -43,6 +44,7 @@ export function createConfiguration(strictMode = true, littleEndian = true): Con
                 new NLTimeUnitWithinFormatParser(),
                 new NLSlashMonthFormatParser(),
                 new NLWeekdayParser(),
+                new NLCasualYearMonthDayParser()
             ],
             refiners: [new NLMergeDateTimeRefiner(), new NLMergeDateRangeRefiner()],
         },

--- a/src/locales/nl/parsers/NLCasualDateParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateParser.ts
@@ -5,7 +5,7 @@ import * as references from "../../../common/casualReferences";
 
 export default class NLCasualDateParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(context: ParsingContext): RegExp {
-        return /(nu|vandaag|morgen|gisteren)(?=\W|$)/i;
+        return /(nu|vandaag|morgen|morgend|gisteren)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {

--- a/src/locales/nl/parsers/NLCasualDateParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateParser.ts
@@ -3,9 +3,9 @@ import { ParsingComponents, ParsingResult } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import * as references from "../../../common/casualReferences";
 
-export default class ENCasualDateParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLCasualDateParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(context: ParsingContext): RegExp {
-        return /(nu|vandaag|vanacht|morgen|morgend|gisteren)(?=\W|$)/i;
+        return /(nu|vandaag|vanavond|morgen|morgend|gisteren|vanochtend)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
@@ -16,6 +16,7 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
             case "nu":
                 return references.now(context.refDate);
 
+            case "vanochtend":
             case "vandaag":
                 return references.today(context.refDate);
 

--- a/src/locales/nl/parsers/NLCasualDateParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateParser.ts
@@ -26,9 +26,6 @@ export default class NLCasualDateParser extends AbstractParserWithWordBoundaryCh
 
             case "gisteren":
                 return references.yesterday(context.refDate);
-
-            case "vanacht":
-                return references.tonight(context.refDate);
         }
 
         return component;

--- a/src/locales/nl/parsers/NLCasualDateParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateParser.ts
@@ -5,7 +5,7 @@ import * as references from "../../../common/casualReferences";
 
 export default class NLCasualDateParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(context: ParsingContext): RegExp {
-        return /(nu|vandaag|vanavond|morgen|morgend|gisteren|vanochtend)(?=\W|$)/i;
+        return /(nu|vandaag|morgen|gisteren)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
@@ -16,12 +16,10 @@ export default class NLCasualDateParser extends AbstractParserWithWordBoundaryCh
             case "nu":
                 return references.now(context.refDate);
 
-            case "vanochtend":
             case "vandaag":
                 return references.today(context.refDate);
 
             case "morgen":
-            case "morgend":
                 return references.tomorrow(context.refDate);
 
             case "gisteren":

--- a/src/locales/nl/parsers/NLCasualDateParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateParser.ts
@@ -20,6 +20,7 @@ export default class NLCasualDateParser extends AbstractParserWithWordBoundaryCh
                 return references.today(context.refDate);
 
             case "morgen":
+            case "morgend":
                 return references.tomorrow(context.refDate);
 
             case "gisteren":

--- a/src/locales/nl/parsers/NLCasualDateTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateTimeParser.ts
@@ -1,0 +1,76 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents, ParsingResult } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import * as references from "../../../common/casualReferences";
+import {Meridiem} from "../../../index";
+import {assignSimilarDate, assignTheNextDay} from "../../../utils/dayjs";
+import dayjs from "dayjs";
+
+/*
+* Find combined words
+* - morgenochtend
+* - morgenmiddag
+* - morgennamiddag
+* - morgenavond
+* - morgennacht
+* - vanochtend
+* - vanmiddag
+* - vannamiddag
+* - vanavond
+* - vannacht
+* - gisterenochtend
+* - gisterenmiddag
+* - gisterennamiddag
+* - gisterenavond
+* - gisterennacht
+* */
+
+const DATE_GROUP = 1;
+const TIME_OF_DAY_GROUP = 2;
+
+export default class NLCasualDateTimeParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(context: ParsingContext): RegExp {
+        return /(gisteren|morgen|van)(ochtend|middag|namiddag|avond|nacht)(?=\W|$)/i;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
+        const dateText = match[DATE_GROUP].toLowerCase();
+        const timeText = match[TIME_OF_DAY_GROUP].toLowerCase();
+        const component = context.createParsingComponents();
+        const targetDate = dayjs(context.refDate);
+
+        switch (dateText) {
+            case "gisteren":
+                assignSimilarDate(component, targetDate.add(-1, "day"));
+                break;
+            case "van":
+                assignSimilarDate(component, targetDate);
+                break;
+            case "morgen":
+                assignTheNextDay(component, targetDate);
+                break;
+        }
+
+        switch (timeText) {
+            case "ochtend":
+                component.imply("meridiem", Meridiem.AM);
+                component.imply("hour", 6);
+                break;
+            case "middag":
+                component.imply("meridiem", Meridiem.AM);
+                component.imply("hour", 12);
+                break;
+            case "namiddag":
+                component.imply("meridiem", Meridiem.PM);
+                component.imply("hour", 15);
+                break;
+
+            case "avond":
+                component.imply("meridiem", Meridiem.PM);
+                component.imply("hour", 20);
+                break;
+        }
+
+        return component;
+    }
+}

--- a/src/locales/nl/parsers/NLCasualDateTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualDateTimeParser.ts
@@ -1,29 +1,28 @@
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents, ParsingResult } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import * as references from "../../../common/casualReferences";
-import {Meridiem} from "../../../index";
-import {assignSimilarDate, assignTheNextDay} from "../../../utils/dayjs";
+import { Meridiem } from "../../../index";
+import { assignSimilarDate, assignTheNextDay } from "../../../utils/dayjs";
 import dayjs from "dayjs";
 
 /*
-* Find combined words
-* - morgenochtend
-* - morgenmiddag
-* - morgennamiddag
-* - morgenavond
-* - morgennacht
-* - vanochtend
-* - vanmiddag
-* - vannamiddag
-* - vanavond
-* - vannacht
-* - gisterenochtend
-* - gisterenmiddag
-* - gisterennamiddag
-* - gisterenavond
-* - gisterennacht
-* */
+ * Find combined words
+ * - morgenochtend
+ * - morgenmiddag
+ * - morgennamiddag
+ * - morgenavond
+ * - morgennacht
+ * - vanochtend
+ * - vanmiddag
+ * - vannamiddag
+ * - vanavond
+ * - vannacht
+ * - gisterenochtend
+ * - gisterenmiddag
+ * - gisterennamiddag
+ * - gisterenavond
+ * - gisterennacht
+ * */
 
 const DATE_GROUP = 1;
 const TIME_OF_DAY_GROUP = 2;

--- a/src/locales/nl/parsers/NLCasualTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualTimeParser.ts
@@ -9,7 +9,7 @@ const MOMENT_GROUP = 2;
 
 export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern() {
-        return /(deze)?\s*(namiddag|vanavond|avond|vannacht|middernacht|vanochtend|ochtend|vanmiddag|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
+        return /(deze)?\s*(namiddag|avond|middernacht|ochtend|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
@@ -29,7 +29,6 @@ export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 15);
                 break;
 
-            case "vanavond":
             case "avond":
             case "'s avonds'":
                 component.imply("meridiem", Meridiem.PM);

--- a/src/locales/nl/parsers/NLCasualTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualTimeParser.ts
@@ -6,7 +6,7 @@ import { assignTheNextDay } from "../../../utils/dayjs";
 
 export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern() {
-        return /(?:this)?\s*(namiddag|vanavond|avond|vannacht|middernacht|vanochtend|ochtend|vanmiddag|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
+        return /(?:deze)?\s*(namiddag|vanavond|avond|vannacht|middernacht|vanochtend|ochtend|vanmiddag|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {

--- a/src/locales/nl/parsers/NLCasualTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualTimeParser.ts
@@ -4,15 +4,16 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 import dayjs from "dayjs";
 import { assignTheNextDay } from "../../../utils/dayjs";
 
-export default class ENCasualTimeParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern() {
-        return /(?:this)?\s*(namiddag|avond|middernacht|ochtend|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
+        return /(?:this)?\s*(namiddag|vanavond|avond|vannacht|middernacht|vanochtend|ochtend|vanmiddag|middag|'s middags|'s avonds|'s ochtends)(?=\W|$)/i;
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const targetDate = dayjs(context.refDate);
         const component = context.createParsingComponents();
 
+        // TODO provide "deze middag, deze avond, deze nacht"
         switch (match[1].toLowerCase()) {
             case "namiddag":
             case "'s namiddags":
@@ -20,6 +21,7 @@ export default class ENCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 15);
                 break;
 
+            case "vanavond":
             case "avond":
             case "'s avonds'":
                 component.imply("meridiem", Meridiem.PM);

--- a/src/locales/nl/parsers/NLCasualTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualTimeParser.ts
@@ -29,6 +29,7 @@ export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 break;
 
             case "middernacht":
+            case "vannacht":
                 assignTheNextDay(component, targetDate);
                 component.imply("hour", 0);
                 component.imply("minute", 0);

--- a/src/locales/nl/parsers/NLCasualYearMonthDayParser.ts
+++ b/src/locales/nl/parsers/NLCasualYearMonthDayParser.ts
@@ -1,0 +1,49 @@
+import { ParsingContext } from "../../../chrono";
+import { MONTH_DICTIONARY } from "../constants";
+import { matchAnyPattern } from "../../../utils/pattern";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+
+/*
+    Date format with slash "/" between numbers like ENSlashDateFormatParser,
+    but this parser expect year before month and date.
+    - YYYY/MM/DD
+    - YYYY-MM-DD
+    - YYYY.MM.DD
+*/
+const PATTERN = new RegExp(
+    `([0-9]{4})[\\.\\/\\s]` +
+        `(?:(${matchAnyPattern(MONTH_DICTIONARY)})|([0-9]{1,2}))[\\.\\/\\s]` +
+        `([0-9]{1,2})` +
+        "(?=\\W|$)",
+    "i"
+);
+
+const YEAR_NUMBER_GROUP = 1;
+const MONTH_NAME_GROUP = 2;
+const MONTH_NUMBER_GROUP = 3;
+const DATE_NUMBER_GROUP = 4;
+
+export default class NLCasualYearMonthDayParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray) {
+        const month = match[MONTH_NUMBER_GROUP]
+            ? parseInt(match[MONTH_NUMBER_GROUP])
+            : MONTH_DICTIONARY[match[MONTH_NAME_GROUP].toLowerCase()];
+
+        if (month < 1 || month > 12) {
+            return null;
+        }
+
+        const year = parseInt(match[YEAR_NUMBER_GROUP]);
+        const day = parseInt(match[DATE_NUMBER_GROUP]);
+
+        return {
+            day: day,
+            month: month,
+            year: year,
+        };
+    }
+}

--- a/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
@@ -7,7 +7,7 @@ import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
 const PATTERN = new RegExp(
-        "(?:on\\s*?)?" +
+    "(?:on\\s*?)?" +
         `(${ORDINAL_NUMBER_PATTERN})` +
         "(?:\\s*" +
         "(?:tot|\\-|\\–|until|through|till|\\s)\\s*" +
@@ -22,7 +22,7 @@ const PATTERN = new RegExp(
         `(${YEAR_PATTERN}(?![^\\s]\\d))` +
         ")?" +
         "(?=\\W|$)",
-        "i"
+    "i"
 );
 
 const MONTH_NAME_GROUP = 3;
@@ -31,14 +31,19 @@ const DATE_TO_GROUP = 2;
 const YEAR_GROUP = 4;
 
 /**
- * The parser for parsing US's date format that begin with month's name.
- *  - January 13
- *  - January 13, 2012
- *  - January 13 - 15, 2012
- * Note: Watch out for:
- *  - January 12:00
- *  - January 12.44
- *  - January 1222344
+ * The parser for parsing BE/NL date format with month's name in full writing
+ *  - 1 januari 2019
+ *  - 01 januari 2019
+ *  - 10 januari 2019
+ *  - 13 januari
+ *  - 10 - 25 maart
+ *  - 10 - 25 maart 2019
+ *  - 1 aug 2019
+ *  - 1 september 200 voor Christus
+ *  - 1 september 2002 na Christus
+ *  - 19 januari 87
+ *  - 12de juli 2013
+ *  - 1ste november 2013
  */
 export default class NLMonthNameMiddleEndianParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {

--- a/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
@@ -1,30 +1,33 @@
 import { ParsingContext } from "../../../chrono";
 import { findYearClosestToRef } from "../../../calculation/years";
-import { MONTH_DICTIONARY } from "../../nl/constants";
-import { ORDINAL_NUMBER_PATTERN, parseOrdinalNumberPattern } from "../../nl/constants";
-import { YEAR_PATTERN, parseYear } from "../../nl/constants";
+import { MONTH_DICTIONARY } from "../constants";
+import { ORDINAL_NUMBER_PATTERN, parseOrdinalNumberPattern } from "../constants";
+import { YEAR_PATTERN, parseYear } from "../constants";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
 const PATTERN = new RegExp(
-    `(${matchAnyPattern(MONTH_DICTIONARY)})` +
-        "(?:-|/|\\s*,?\\s*)" +
-        `(${ORDINAL_NUMBER_PATTERN})(?!\\s*)\\s*` +
-        "(?:" +
-        "(?:to|\\-)\\s*" +
-        `(${ORDINAL_NUMBER_PATTERN})\\s*` +
+        "(?:on\\s*?)?" +
+        `(${ORDINAL_NUMBER_PATTERN})` +
+        "(?:\\s*" +
+        "(?:tot|\\-|\\–|until|through|till|\\s)\\s*" +
+        `(${ORDINAL_NUMBER_PATTERN})` +
         ")?" +
+        "(?:-|/|\\s*(?:of)?\\s*)" +
+        "(" +
+        matchAnyPattern(MONTH_DICTIONARY) +
+        ")" +
         "(?:" +
-        "(?:-|/|\\s*,?\\s*)" +
-        `(${YEAR_PATTERN})` +
+        "(?:-|/|,?\\s*)" +
+        `(${YEAR_PATTERN}(?![^\\s]\\d))` +
         ")?" +
-        "(?=\\W|$)(?!\\:\\d)",
-    "i"
+        "(?=\\W|$)",
+        "i"
 );
 
-const MONTH_NAME_GROUP = 1;
-const DATE_GROUP = 2;
-const DATE_TO_GROUP = 3;
+const MONTH_NAME_GROUP = 3;
+const DATE_GROUP = 1;
+const DATE_TO_GROUP = 2;
 const YEAR_GROUP = 4;
 
 /**

--- a/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
@@ -1,8 +1,8 @@
 import { ParsingContext } from "../../../chrono";
 import { findYearClosestToRef } from "../../../calculation/years";
-import { MONTH_DICTIONARY } from "../../en/constants";
-import { ORDINAL_NUMBER_PATTERN, parseOrdinalNumberPattern } from "../../en/constants";
-import { YEAR_PATTERN, parseYear } from "../../en/constants";
+import { MONTH_DICTIONARY } from "../../nl/constants";
+import { ORDINAL_NUMBER_PATTERN, parseOrdinalNumberPattern } from "../../nl/constants";
+import { YEAR_PATTERN, parseYear } from "../../nl/constants";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
@@ -37,7 +37,7 @@ const YEAR_GROUP = 4;
  *  - January 12.44
  *  - January 1222344
  */
-export default class ENMonthNameMiddleEndianParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLMonthNameMiddleEndianParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return PATTERN;
     }

--- a/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameMiddleEndianParser.ts
@@ -54,6 +54,8 @@ export default class NLMonthNameMiddleEndianParser extends AbstractParserWithWor
         const month = MONTH_DICTIONARY[match[MONTH_NAME_GROUP].toLowerCase()];
         const day = parseOrdinalNumberPattern(match[DATE_GROUP]);
         if (day > 31) {
+            // e.g. "[96 Aug]" => "9[6 Aug]", we need to shift away from the next number
+            match.index = match.index + match[DATE_GROUP].length;
             return null;
         }
 

--- a/src/locales/nl/parsers/NLMonthNameParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameParser.ts
@@ -4,9 +4,12 @@ import { findYearClosestToRef } from "../../../calculation/years";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { YEAR_PATTERN, parseYear } from "../constants";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { ORDINAL_NUMBER_PATTERN } from "../../nl/constants";
+import { parseOrdinalNumberPattern } from "../../../../dist/locales/nl/constants";
 
 const PATTERN = new RegExp(
-    `(${matchAnyPattern(MONTH_DICTIONARY)})` +
+    `(${ORDINAL_NUMBER_PATTERN})\\s*` +
+        `(${matchAnyPattern(MONTH_DICTIONARY)})` +
         "\\s*" +
         "(?:" +
         `[,-]?\\s*(${YEAR_PATTERN})?` +
@@ -15,8 +18,9 @@ const PATTERN = new RegExp(
     "i"
 );
 
-const MONTH_NAME_GROUP = 1;
-const YEAR_GROUP = 2;
+const DAY_GROUP = 1;
+const MONTH_NAME_GROUP = 2;
+const YEAR_GROUP = 3;
 
 /**
  * The parser for parsing month name and year.
@@ -24,7 +28,7 @@ const YEAR_GROUP = 2;
  * - January 2012
  * - January
  */
-export default class ENMonthNameParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLMonthNameParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return PATTERN;
     }
@@ -35,7 +39,12 @@ export default class ENMonthNameParser extends AbstractParserWithWordBoundaryChe
         }
 
         const components = context.createParsingComponents();
-        components.imply("day", 1);
+
+        const day = parseOrdinalNumberPattern(match[DAY_GROUP]);
+        if (day > 31) {
+            return null;
+        }
+        components.assign("day", day);
 
         const monthName = match[MONTH_NAME_GROUP];
         const month = MONTH_DICTIONARY[monthName.toLowerCase()];

--- a/src/locales/nl/parsers/NLMonthNameParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameParser.ts
@@ -4,29 +4,25 @@ import { findYearClosestToRef } from "../../../calculation/years";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { YEAR_PATTERN, parseYear } from "../constants";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { ORDINAL_NUMBER_PATTERN } from "../../nl/constants";
-import { parseOrdinalNumberPattern } from "../../../../dist/locales/nl/constants";
 
 const PATTERN = new RegExp(
-    `(${ORDINAL_NUMBER_PATTERN})\\s*` +
-        `(${matchAnyPattern(MONTH_DICTIONARY)})` +
-        "\\s*" +
-        "(?:" +
+    `(${matchAnyPattern(MONTH_DICTIONARY)})` +
+        `\\s*` +
+        `(?:` +
         `[,-]?\\s*(${YEAR_PATTERN})?` +
         ")?" +
         "(?=[^\\s\\w]|\\s+[^0-9]|\\s+$|$)",
     "i"
 );
 
-const DAY_GROUP = 1;
-const MONTH_NAME_GROUP = 2;
-const YEAR_GROUP = 3;
+const MONTH_NAME_GROUP = 1;
+const YEAR_GROUP = 2;
 
 /**
  * The parser for parsing month name and year.
- * - January, 2012
- * - January 2012
- * - January
+ * - januari, 2012
+ * - januari 2012
+ * - januari
  */
 export default class NLMonthNameParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
@@ -34,17 +30,12 @@ export default class NLMonthNameParser extends AbstractParserWithWordBoundaryChe
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
-        if (match[0].length <= 3) {
+        if (match[0].length <= 2) {
             return null;
         }
 
         const components = context.createParsingComponents();
-
-        const day = parseOrdinalNumberPattern(match[DAY_GROUP]);
-        if (day > 31) {
-            return null;
-        }
-        components.assign("day", day);
+        components.imply("day", 1);
 
         const monthName = match[MONTH_NAME_GROUP];
         const month = MONTH_DICTIONARY[monthName.toLowerCase()];

--- a/src/locales/nl/parsers/NLMonthNameParser.ts
+++ b/src/locales/nl/parsers/NLMonthNameParser.ts
@@ -30,10 +30,6 @@ export default class NLMonthNameParser extends AbstractParserWithWordBoundaryChe
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
-        if (match[0].length <= 2) {
-            return null;
-        }
-
         const components = context.createParsingComponents();
         components.imply("day", 1);
 

--- a/src/locales/nl/parsers/NLSlashMonthFormatParser.ts
+++ b/src/locales/nl/parsers/NLSlashMonthFormatParser.ts
@@ -12,7 +12,7 @@ const YEAR_GROUP = 2;
  * - 11/05
  * - 06/2005
  */
-export default class ENSlashMonthFormatParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLSlashMonthFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return PATTERN;
     }

--- a/src/locales/nl/parsers/NLTimeExpressionParser.ts
+++ b/src/locales/nl/parsers/NLTimeExpressionParser.ts
@@ -4,11 +4,11 @@ import { ParsingContext } from "../../../chrono";
 
 export default class NLTimeExpressionParser extends AbstractTimeExpressionParser {
     primaryPrefix(): string {
-        return "(?:(?:[àa])\\s*)?";
+        return "(?:(?:om)\\s*)?";
     }
 
     followingPhase(): string {
-        return "\\s*(?:\\-|\\–|\\~|\\〜|[àa]|\\?)\\s*";
+        return "\\s*(?:\\-|\\–|\\~|\\〜|om|\\?)\\s*";
     }
 
     extractPrimaryTimeComponents(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | null {

--- a/src/locales/nl/parsers/NLTimeExpressionParser.ts
+++ b/src/locales/nl/parsers/NLTimeExpressionParser.ts
@@ -1,0 +1,22 @@
+import { AbstractTimeExpressionParser } from "../../../common/parsers/AbstractTimeExpressionParser";
+import { ParsingComponents } from "../../../results";
+import { ParsingContext } from "../../../chrono";
+
+export default class NLTimeExpressionParser extends AbstractTimeExpressionParser {
+    primaryPrefix(): string {
+        return "(?:(?:[àa])\\s*)?";
+    }
+
+    followingPhase(): string {
+        return "\\s*(?:\\-|\\–|\\~|\\〜|[àa]|\\?)\\s*";
+    }
+
+    extractPrimaryTimeComponents(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | null {
+        // This looks more like a year e.g. 2020
+        if (match[0].match(/^\s*\d{4}\s*$/)) {
+            return null;
+        }
+
+        return super.extractPrimaryTimeComponents(context, match);
+    }
+}

--- a/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
@@ -1,9 +1,9 @@
-import { TIME_UNITS_PATTERN, parseTimeUnits } from "../../en/constants";
+import { TIME_UNITS_PATTERN, parseTimeUnits } from "../../nl/constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
-export default class ENTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return new RegExp(`(?:binnen|in)\\s*` + "(" + TIME_UNITS_PATTERN + ")" + `(?=\\W|$)`, "i");
     }

--- a/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
@@ -5,7 +5,7 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 
 export default class NLTimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
-        return new RegExp(`(?:binnen|in)\\s*` + "(" + TIME_UNITS_PATTERN + ")" + `(?=\\W|$)`, "i");
+        return new RegExp(`(?:binnen|in|binnen de|voor)\\s*` + "(" + TIME_UNITS_PATTERN + ")" + `(?=\\W|$)`, "i");
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {

--- a/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
@@ -1,4 +1,4 @@
-import { TIME_UNITS_PATTERN, parseTimeUnits } from "../../nl/constants";
+import { TIME_UNITS_PATTERN, parseTimeUnits } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";

--- a/src/locales/nl/parsers/NLWeekdayParser.ts
+++ b/src/locales/nl/parsers/NLWeekdayParser.ts
@@ -7,11 +7,9 @@ import { toDayJSWeekday } from "../../../calculation/weeks";
 
 const PATTERN = new RegExp(
     "(?:(?:\\,|\\(|\\（)\\s*)?" +
-        "(?:on\\s*?)?" +
-        "(?:(deze|vorige|volgende)\\s*)?" +
+        "(?:op\\s*?)?" +
+        "(?:(deze|vorige|volgende)\\s*(?:week\\s*)?)?" +
         `(${matchAnyPattern(WEEKDAY_DICTIONARY)})` +
-        "(?:\\s*(?:\\,|\\)|\\）))?" +
-        "(?:\\s*(deze|vorige|volgende)\\s*week)?" +
         "(?=\\W|$)",
     "i"
 );

--- a/src/locales/nl/parsers/NLWeekdayParser.ts
+++ b/src/locales/nl/parsers/NLWeekdayParser.ts
@@ -8,10 +8,10 @@ import { toDayJSWeekday } from "../../../calculation/weeks";
 const PATTERN = new RegExp(
     "(?:(?:\\,|\\(|\\（)\\s*)?" +
         "(?:on\\s*?)?" +
-        "(?:(deze|last|vorige|volgende)\\s*)?" +
+        "(?:(deze|vorige|volgende)\\s*)?" +
         `(${matchAnyPattern(WEEKDAY_DICTIONARY)})` +
         "(?:\\s*(?:\\,|\\)|\\）))?" +
-        "(?:\\s*(deze|last|vorige|volgende)\\s*week)?" +
+        "(?:\\s*(deze|vorige|volgende)\\s*week)?" +
         "(?=\\W|$)",
     "i"
 );
@@ -35,7 +35,7 @@ export default class NLWeekdayParser extends AbstractParserWithWordBoundaryCheck
         modifierWord = modifierWord.toLowerCase();
 
         let modifier = null;
-        if (modifierWord == "last" || modifierWord == "vorige") {
+        if (modifierWord == "vorige") {
             modifier = "last";
         } else if (modifierWord == "volgende") {
             modifier = "next";

--- a/src/locales/nl/parsers/NLWeekdayParser.ts
+++ b/src/locales/nl/parsers/NLWeekdayParser.ts
@@ -1,6 +1,6 @@
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import { WEEKDAY_DICTIONARY } from "../../en/constants";
+import { WEEKDAY_DICTIONARY } from "../../nl/constants";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { toDayJSWeekday } from "../../../calculation/weeks";
@@ -8,10 +8,10 @@ import { toDayJSWeekday } from "../../../calculation/weeks";
 const PATTERN = new RegExp(
     "(?:(?:\\,|\\(|\\（)\\s*)?" +
         "(?:on\\s*?)?" +
-        "(?:(this|last|past|next)\\s*)?" +
+        "(?:(deze|last|vorige|volgende)\\s*)?" +
         `(${matchAnyPattern(WEEKDAY_DICTIONARY)})` +
         "(?:\\s*(?:\\,|\\)|\\）))?" +
-        "(?:\\s*(this|last|past|next)\\s*week)?" +
+        "(?:\\s*(deze|last|vorige|volgende)\\s*week)?" +
         "(?=\\W|$)",
     "i"
 );
@@ -20,7 +20,7 @@ const PREFIX_GROUP = 1;
 const WEEKDAY_GROUP = 2;
 const POSTFIX_GROUP = 3;
 
-export default class ENWeekdayParser extends AbstractParserWithWordBoundaryChecking {
+export default class NLWeekdayParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
         return PATTERN;
     }
@@ -35,11 +35,11 @@ export default class ENWeekdayParser extends AbstractParserWithWordBoundaryCheck
         modifierWord = modifierWord.toLowerCase();
 
         let modifier = null;
-        if (modifierWord == "last" || modifierWord == "past") {
+        if (modifierWord == "last" || modifierWord == "vorige") {
             modifier = "last";
-        } else if (modifierWord == "next") {
+        } else if (modifierWord == "volgende") {
             modifier = "next";
-        } else if (modifierWord == "this") {
+        } else if (modifierWord == "deze") {
             modifier = "this";
         }
 

--- a/src/locales/nl/refiners/NLMergeDateTimeRefiner.ts
+++ b/src/locales/nl/refiners/NLMergeDateTimeRefiner.ts
@@ -8,6 +8,6 @@ import AbstractMergeDateTimeRefiner from "../../../common/refiners/AbstractMerge
  */
 export default class NLMergeDateTimeRefiner extends AbstractMergeDateTimeRefiner {
     patternBetween(): RegExp {
-        return new RegExp("^\\s*(om|na|voor|,|-)?\\s*$");
+        return new RegExp("^\\s*(om|na|voor|in de|,|-)?\\s*$");
     }
 }

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -222,34 +222,34 @@ test("Test - Casual time implication", () => {
 });
 
 test("Test - Random text", () => {
-    testSingleCase(chrono, "tonight", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "vanavond", new Date(2012, 1 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(1);
         expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono.nl, "vanavond 22:00", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
         expect(result.start.get("hour")).toBe(22);
-        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
-    });
-
-    testSingleCase(chrono, "tonight 8pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("hour")).toBe(20);
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(1);
         expect(result.start.get("day")).toBe(1);
         expect(result.start.get("meridiem")).toBe(Meridiem.PM);
     });
 
-    testSingleCase(chrono, "tonight at 8", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "vanavond om 21:00", new Date(2012, 1 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
-        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("hour")).toBe(21);
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(1);
         expect(result.start.get("day")).toBe(1);
         expect(result.start.get("meridiem")).toBe(Meridiem.PM);
     });
 
-    testSingleCase(chrono, "tomorrow before 4pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "morgen voor 16:00", new Date(2012, 1 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("hour")).toBe(16);
         expect(result.start.get("year")).toBe(2012);
@@ -258,7 +258,7 @@ test("Test - Random text", () => {
         expect(result.start.get("meridiem")).toBe(Meridiem.PM);
     });
 
-    testSingleCase(chrono, "tomorrow after 4pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "morgen na 16:00", new Date(2012, 1 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("hour")).toBe(16);
         expect(result.start.get("year")).toBe(2012);
@@ -267,17 +267,12 @@ test("Test - Random text", () => {
         expect(result.start.get("meridiem")).toBe(Meridiem.PM);
     });
 
-    testSingleCase(chrono, "thurs", (result, text) => {
+    testSingleCase(chrono.nl, "donderdag", (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("weekday")).toBe(4);
     });
 
-    testSingleCase(chrono, "thurs", (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("weekday")).toBe(4);
-    });
-
-    testSingleCase(chrono, "this evening", new Date(2016, 10 - 1, 1), (result, text) => {
+    testSingleCase(chrono.nl, "deze avond", new Date(2016, 10 - 1, 1), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
@@ -285,7 +280,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(20);
     });
 
-    testSingleCase(chrono, "yesterday afternoon", new Date(2016, 10 - 1, 1), (result, text) => {
+    testSingleCase(chrono.nl, "gisteren namiddag", new Date(2016, 10 - 1, 1), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(9);
@@ -293,7 +288,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(15);
     });
 
-    testSingleCase(chrono, "tomorrow morning", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+    testSingleCase(chrono.nl, "morgen ochtend", new Date(2016, 10 - 1, 1, 8), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
@@ -301,7 +296,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(6);
     });
 
-    testSingleCase(chrono, "this afternoon at 3", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+    testSingleCase(chrono.nl, "deze namiddag om 15:00", new Date(2016, 10 - 1, 1, 8), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -1,0 +1,376 @@
+import * as chrono from "../../src/";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+import { Meridiem } from "../../src/";
+
+test("Test - Single Expression", () => {
+    testSingleCase(chrono.nl, "De deadline is nu", new Date(2012, 7, 10, 8, 9, 10, 11), (result) => {
+        expect(result.index).toBe(15);
+        expect(result.text).toBe("nu");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(8);
+        expect(result.start.get("minute")).toBe(9);
+        expect(result.start.get("second")).toBe(10);
+        expect(result.start.get("millisecond")).toBe(11);
+        expect(result.start.get("timezoneOffset")).toBe(result.refDate.getTimezoneOffset() * -1);
+
+        expect(result.start).toBeDate(result.refDate);
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 8, 9, 10, 11));
+    });
+
+    testSingleCase(chrono.nl, "De deadline is vandaag", new Date(2012, 7, 10, 14, 12), (result) => {
+        expect(result.index).toBe(15);
+        expect(result.text).toBe("vandaag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 14, 12));
+    });
+
+    testSingleCase(chrono.nl, "De deadline is morgen", new Date(2012, 7, 10, 17, 10), (result) => {
+        expect(result.index).toBe(15);
+        expect(result.text).toBe("morgen");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 11, 17, 10));
+    });
+
+    testSingleCase(chrono.nl, "De deadline is morgen", new Date(2012, 7, 10, 1), (result) => {
+        expect(result.start).toBeDate(new Date(2012, 7, 11, 1));
+    });
+
+    testSingleCase(chrono.nl, "De deadline was gisteren", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("gisteren");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 9, 12));
+    });
+
+    /* not implemented
+    testSingleCase(chrono.casual, "The Deadline was last night ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(17);
+        expect(result.text).toBe("last night");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("hour")).toBe(0);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 9, 0));
+    });
+
+    testSingleCase(chrono.casual, "The Deadline was this morning ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(17);
+        expect(result.text).toBe("this morning");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 6));
+    });
+
+    testSingleCase(chrono.casual, "The Deadline was this afternoon ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(17);
+        expect(result.text).toBe("this afternoon");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 15));
+    });
+
+    testSingleCase(chrono.casual, "The Deadline was this evening ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(17);
+        expect(result.text).toBe("this evening");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(20);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 20));
+    });*/
+
+    testSingleCase(chrono.nl, "De deadline is vanavond", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.text).toBe("vanavond");
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(20);
+    });
+
+    /* not implemented
+    // "Midnight" at 0~1AM, assume it's the coming midnight of following day
+    // This is similar to "Tomorrow" at 0~1AM
+    testSingleCase(chrono.casual, "The Deadline was midnight ", new Date(2012, 7, 10, 1), (result) => {
+        expect(result.text).toBe("midnight");
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(0);
+    });*/
+});
+
+test("Test - Combined Expression", () => {
+    testSingleCase(chrono.nl, "De deadline van is vandaag om 17:00", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(19);
+        expect(result.text).toBe("vandaag om 17:00");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(17);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 17));
+    });
+
+    testSingleCase(chrono.nl, "morgen middag", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
+    });
+});
+
+test("Test - Casual date range", () => {
+    // TODO support volgende **week** vrijdag
+    // TODO provide test for range with "-" dash
+    testSingleCase(chrono.nl, "The event is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {
+        expect(result.index).toBe(13);
+        expect(result.text).toBe("vandaag - volgende vrijdag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(4);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 4, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(10);
+        expect(result.end.get("hour")).toBe(12);
+
+        expect(result.end).toBeDate(new Date(2012, 7, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "The event is vandaag - volgende vrijdag", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(13);
+        expect(result.text).toBe("vandaag - volgende vrijdag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(17);
+        expect(result.end.get("hour")).toBe(12);
+
+        expect(result.end).toBeDate(new Date(2012, 7, 17, 12));
+    });
+});
+
+// TODO should be "vanochtend" or "deze ochtend" instead of "vandaag ochtend"
+test("Test - Casual time implication", () => {
+    testSingleCase(
+        chrono.nl,
+        "annual leave from vandaag ochtend tot morgen",
+        new Date(2012, 8 - 1, 4, 12),
+        (result) => {
+            expect(result.text).toBe("vandaag ochtend tot morgen");
+
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(4);
+            expect(result.start.get("hour")).toBe(6);
+            expect(result.start.isCertain("hour")).toBe(false);
+
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(5);
+            expect(result.end.get("hour")).toBe(12);
+            expect(result.end.isCertain("hour")).toBe(false);
+        }
+    );
+
+    testSingleCase(
+        chrono.nl,
+        "annual leave from vandaag tot morgen namiddag",
+        new Date(2012, 8 - 1, 4, 12),
+        (result) => {
+            expect(result.text).toBe("vandaag tot morgen namiddag");
+
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(4);
+            expect(result.start.get("hour")).toBe(12);
+            expect(result.start.isCertain("hour")).toBe(false);
+
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(5);
+            expect(result.end.get("hour")).toBe(15);
+            expect(result.end.isCertain("hour")).toBe(false);
+        }
+    );
+});
+
+test("Test - Random text", () => {
+    testSingleCase(chrono, "tonight", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(22);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono, "tonight 8pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono, "tonight at 8", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono, "tomorrow before 4pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(16);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(2);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono, "tomorrow after 4pm", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(16);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(2);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+
+    testSingleCase(chrono, "thurs", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("weekday")).toBe(4);
+    });
+
+    testSingleCase(chrono, "thurs", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("weekday")).toBe(4);
+    });
+
+    testSingleCase(chrono, "this evening", new Date(2016, 10 - 1, 1), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(20);
+    });
+
+    testSingleCase(chrono, "yesterday afternoon", new Date(2016, 10 - 1, 1), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(30);
+        expect(result.start.get("hour")).toBe(15);
+    });
+
+    testSingleCase(chrono, "tomorrow morning", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(2);
+        expect(result.start.get("hour")).toBe(6);
+    });
+
+    testSingleCase(chrono, "this afternoon at 3", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(15);
+    });
+});
+
+test("Test - Casual time with timezone", () => {
+    testSingleCase(chrono, "Jan 1, 2020 Morning UTC", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2020);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start.get("timezoneOffset")).toStrictEqual(0);
+        expect(result).toBeDate(new Date("2020-01-01T06:00:00.000Z"));
+    });
+
+    testSingleCase(chrono, "Jan 1, 2020 Evening JST", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2020);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(20);
+
+        expect(result.start.get("timezoneOffset")).toStrictEqual(540);
+        expect(result).toBeDate(new Date("Wed Jan 01 2020 20:00:00 GMT+0900 (Japan Standard Time)"));
+    });
+});
+
+test("Test - Random negative text", () => {
+    testUnexpectedResult(chrono.nl, "notoday");
+
+    testUnexpectedResult(chrono.nl, "tdtmr");
+
+    testUnexpectedResult(chrono.nl, "xyesterday");
+
+    testUnexpectedResult(chrono.nl, "nowhere");
+
+    testUnexpectedResult(chrono.nl, "noway");
+
+    testUnexpectedResult(chrono.nl, "knowledge");
+
+    testUnexpectedResult(chrono.nl, "mar");
+
+    testUnexpectedResult(chrono.nl, "jan");
+});

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -214,7 +214,7 @@ test("Test - Casual combined datetime expressions", () => {
 
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 20));
     });
-})
+});
 
 test("Test - Casual date range", () => {
     testSingleCase(chrono.nl, "Het evenement is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -368,11 +368,4 @@ test("Test - Random negative text", () => {
     testUnexpectedResult(chrono.nl, "noway");
 
     testUnexpectedResult(chrono.nl, "knowledge");
-
-    // TODO fix this, should we allow mar and jan?
-    /*
-    testUnexpectedResult(chrono.nl, "mar");
-
-    testUnexpectedResult(chrono.nl, "jan");
-    */
 });

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -122,16 +122,16 @@ test("Test - Single Expression", () => {
         expect(result.start.get("hour")).toBe(20);
     });
 
-    /* not implemented
+
     // "Midnight" at 0~1AM, assume it's the coming midnight of following day
     // This is similar to "Tomorrow" at 0~1AM
-    testSingleCase(chrono.casual, "The Deadline was midnight ", new Date(2012, 7, 10, 1), (result) => {
-        expect(result.text).toBe("midnight");
+    testSingleCase(chrono.nl, "The Deadline is om middernacht ", new Date(2012, 7, 10, 1), (result) => {
+        expect(result.text).toBe("middernacht");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(11);
         expect(result.start.get("hour")).toBe(0);
-    });*/
+    });
 });
 
 test("Test - Combined Expression", () => {

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -131,9 +131,73 @@ test("Test - Combined Expression", () => {
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 17));
     });
+});
 
-    // TODO should be "morgenmiddag"
-    testSingleCase(chrono.nl, "morgen middag", new Date(2012, 8 - 1, 10, 14), (result) => {
+test("Test - Casual combined datetime expressions", () => {
+    testSingleCase(chrono.nl, "gisterenochtend", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 6));
+    });
+
+    testSingleCase(chrono.nl, "gisterenmiddag", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
+    });
+
+    testSingleCase(chrono.nl, "gisterenavond", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("hour")).toBe(20);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 20));
+    });
+
+    testSingleCase(chrono.nl, "vanochtend", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
+    });
+
+    testSingleCase(chrono.nl, "vanmiddag", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "vanavond", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(20);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 20));
+    });
+
+    testSingleCase(chrono.nl, "morgenochtend", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 6));
+    });
+
+    testSingleCase(chrono.nl, "morgenmiddag", new Date(2012, 8 - 1, 10, 14), (result) => {
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(11);
@@ -141,7 +205,16 @@ test("Test - Combined Expression", () => {
 
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
     });
-});
+
+    testSingleCase(chrono.nl, "morgenavond", new Date(2012, 8 - 1, 10, 14), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(20);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 20));
+    });
+})
 
 test("Test - Casual date range", () => {
     testSingleCase(chrono.nl, "Het evenement is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {
@@ -188,13 +261,12 @@ test("Test - Casual date range", () => {
 });
 
 test("Test - Casual time implication", () => {
-    // TODO should be "morgennamiddag"
     testSingleCase(
         chrono.nl,
-        "jaarlijks verlof vanaf vandaag tot morgen namiddag",
+        "jaarlijks verlof vanaf vandaag tot morgennamiddag",
         new Date(2012, 8 - 1, 4, 12),
         (result) => {
-            expect(result.text).toBe("vandaag tot morgen namiddag");
+            expect(result.text).toBe("vandaag tot morgennamiddag");
 
             expect(result.start.get("month")).toBe(8);
             expect(result.start.get("day")).toBe(4);
@@ -287,8 +359,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(20);
     });
 
-    // TODO: should be "gisterennamiddag"
-    testSingleCase(chrono.nl, "gisteren namiddag", new Date(2016, 10 - 1, 1), (result, text) => {
+    testSingleCase(chrono.nl, "gisterennamiddag", new Date(2016, 10 - 1, 1), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(9);
@@ -296,8 +367,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(15);
     });
 
-    // TODO: should be "morgenochtend"
-    testSingleCase(chrono.nl, "morgen ochtend", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+    testSingleCase(chrono.nl, "morgenochtend", new Date(2016, 10 - 1, 1, 8), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -310,6 +310,15 @@ test("Test - Random text", () => {
         expect(result.start.get("meridiem")).toBe(Meridiem.PM);
     });
 
+    testSingleCase(chrono.nl, "middag", new Date(2012, 1 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("meridiem")).toBe(Meridiem.AM);
+    });
+
     testSingleCase(chrono.nl, "vanavond 22:00", new Date(2012, 1 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("hour")).toBe(22);

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -61,23 +61,9 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 9, 12));
     });
 
-    /* not implemented
-    testSingleCase(chrono.casual, "The Deadline was last night ", new Date(2012, 7, 10, 12), (result) => {
+    testSingleCase(chrono.nl, "The Deadline was deze ochtend", new Date(2012, 7, 10, 12), (result) => {
         expect(result.index).toBe(17);
-        expect(result.text).toBe("last night");
-
-        expect(result.start).not.toBeNull();
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(9);
-        expect(result.start.get("hour")).toBe(0);
-
-        expect(result.start).toBeDate(new Date(2012, 7, 9, 0));
-    });
-
-    testSingleCase(chrono.casual, "The Deadline was this morning ", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(17);
-        expect(result.text).toBe("this morning");
+        expect(result.text).toBe("deze ochtend");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -88,9 +74,10 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 6));
     });
 
-    testSingleCase(chrono.casual, "The Deadline was this afternoon ", new Date(2012, 7, 10, 12), (result) => {
+
+    testSingleCase(chrono.nl, "The Deadline was deze namiddag ", new Date(2012, 7, 10, 12), (result) => {
         expect(result.index).toBe(17);
-        expect(result.text).toBe("this afternoon");
+        expect(result.text).toBe("deze namiddag");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -101,9 +88,9 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 15));
     });
 
-    testSingleCase(chrono.casual, "The Deadline was this evening ", new Date(2012, 7, 10, 12), (result) => {
+    testSingleCase(chrono.nl, "The Deadline was deze avond ", new Date(2012, 7, 10, 12), (result) => {
         expect(result.index).toBe(17);
-        expect(result.text).toBe("this evening");
+        expect(result.text).toBe("deze avond");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -112,7 +99,7 @@ test("Test - Single Expression", () => {
         expect(result.start.get("hour")).toBe(20);
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 20));
-    });*/
+    });
 
     testSingleCase(chrono.nl, "De deadline is vanavond", new Date(2012, 7, 10, 12), (result) => {
         expect(result.text).toBe("vanavond");
@@ -157,8 +144,6 @@ test("Test - Combined Expression", () => {
 });
 
 test("Test - Casual date range", () => {
-    // TODO support volgende **week** vrijdag
-    // TODO provide test for range with "-" dash
     testSingleCase(chrono.nl, "The event is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {
         expect(result.index).toBe(13);
         expect(result.text).toBe("vandaag - volgende vrijdag");
@@ -202,27 +187,7 @@ test("Test - Casual date range", () => {
     });
 });
 
-// TODO should be "vanochtend" or "deze ochtend" instead of "vandaag ochtend"
 test("Test - Casual time implication", () => {
-    testSingleCase(
-        chrono.nl,
-        "annual leave from vandaag ochtend tot morgen",
-        new Date(2012, 8 - 1, 4, 12),
-        (result) => {
-            expect(result.text).toBe("vandaag ochtend tot morgen");
-
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(4);
-            expect(result.start.get("hour")).toBe(6);
-            expect(result.start.isCertain("hour")).toBe(false);
-
-            expect(result.end.get("month")).toBe(8);
-            expect(result.end.get("day")).toBe(5);
-            expect(result.end.get("hour")).toBe(12);
-            expect(result.end.isCertain("hour")).toBe(false);
-        }
-    );
-
     testSingleCase(
         chrono.nl,
         "annual leave from vandaag tot morgen namiddag",
@@ -238,6 +203,25 @@ test("Test - Casual time implication", () => {
             expect(result.end.get("month")).toBe(8);
             expect(result.end.get("day")).toBe(5);
             expect(result.end.get("hour")).toBe(15);
+            expect(result.end.isCertain("hour")).toBe(false);
+        }
+    );
+
+    testSingleCase(
+        chrono.nl,
+        "annual leave from deze ochtend tot morgen",
+        new Date(2012, 8 - 1, 4, 12),
+        (result) => {
+            expect(result.text).toBe("deze ochtend tot morgen");
+
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(4);
+            expect(result.start.get("hour")).toBe(6);
+            expect(result.start.isCertain("hour")).toBe(false);
+
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(5);
+            expect(result.end.get("hour")).toBe(12);
             expect(result.end.isCertain("hour")).toBe(false);
         }
     );

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -122,7 +122,6 @@ test("Test - Single Expression", () => {
         expect(result.start.get("hour")).toBe(20);
     });
 
-
     // "Midnight" at 0~1AM, assume it's the coming midnight of following day
     // This is similar to "Tomorrow" at 0~1AM
     testSingleCase(chrono.nl, "The Deadline is om middernacht ", new Date(2012, 7, 10, 1), (result) => {

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -61,8 +61,8 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 9, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline was deze ochtend", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(17);
+    testSingleCase(chrono.nl, "De Deadline was deze ochtend", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(16);
         expect(result.text).toBe("deze ochtend");
 
         expect(result.start).not.toBeNull();
@@ -74,8 +74,8 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 6));
     });
 
-    testSingleCase(chrono.nl, "The Deadline was deze namiddag ", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(17);
+    testSingleCase(chrono.nl, "De Deadline was deze namiddag ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(16);
         expect(result.text).toBe("deze namiddag");
 
         expect(result.start).not.toBeNull();
@@ -87,8 +87,8 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 15));
     });
 
-    testSingleCase(chrono.nl, "The Deadline was deze avond ", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(17);
+    testSingleCase(chrono.nl, "De Deadline was deze avond ", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(16);
         expect(result.text).toBe("deze avond");
 
         expect(result.start).not.toBeNull();
@@ -120,8 +120,8 @@ test("Test - Single Expression", () => {
 });
 
 test("Test - Combined Expression", () => {
-    testSingleCase(chrono.nl, "De deadline van is vandaag om 17:00", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(19);
+    testSingleCase(chrono.nl, "De deadline is vandaag om 17:00", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("vandaag om 17:00");
 
         expect(result.start.get("year")).toBe(2012);
@@ -132,6 +132,7 @@ test("Test - Combined Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 17));
     });
 
+    // TODO should be "morgenmiddag"
     testSingleCase(chrono.nl, "morgen middag", new Date(2012, 8 - 1, 10, 14), (result) => {
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
@@ -143,8 +144,8 @@ test("Test - Combined Expression", () => {
 });
 
 test("Test - Casual date range", () => {
-    testSingleCase(chrono.nl, "The event is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {
-        expect(result.index).toBe(13);
+    testSingleCase(chrono.nl, "Het evenement is vandaag - volgende vrijdag", new Date(2012, 7, 4, 12), (result) => {
+        expect(result.index).toBe(17);
         expect(result.text).toBe("vandaag - volgende vrijdag");
 
         expect(result.start).not.toBeNull();
@@ -164,8 +165,8 @@ test("Test - Casual date range", () => {
         expect(result.end).toBeDate(new Date(2012, 7, 10, 12));
     });
 
-    testSingleCase(chrono.nl, "The event is vandaag - volgende vrijdag", new Date(2012, 7, 10, 12), (result) => {
-        expect(result.index).toBe(13);
+    testSingleCase(chrono.nl, "Het evenement is vandaag - volgende vrijdag", new Date(2012, 7, 10, 12), (result) => {
+        expect(result.index).toBe(17);
         expect(result.text).toBe("vandaag - volgende vrijdag");
 
         expect(result.start).not.toBeNull();
@@ -187,9 +188,10 @@ test("Test - Casual date range", () => {
 });
 
 test("Test - Casual time implication", () => {
+    // TODO should be "morgennamiddag"
     testSingleCase(
         chrono.nl,
-        "annual leave from vandaag tot morgen namiddag",
+        "jaarlijks verlof vanaf vandaag tot morgen namiddag",
         new Date(2012, 8 - 1, 4, 12),
         (result) => {
             expect(result.text).toBe("vandaag tot morgen namiddag");
@@ -206,19 +208,24 @@ test("Test - Casual time implication", () => {
         }
     );
 
-    testSingleCase(chrono.nl, "annual leave from deze ochtend tot morgen", new Date(2012, 8 - 1, 4, 12), (result) => {
-        expect(result.text).toBe("deze ochtend tot morgen");
+    testSingleCase(
+        chrono.nl,
+        "jaarlijks verlof vanaf deze ochtend tot morgen",
+        new Date(2012, 8 - 1, 4, 12),
+        (result) => {
+            expect(result.text).toBe("deze ochtend tot morgen");
 
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(4);
-        expect(result.start.get("hour")).toBe(6);
-        expect(result.start.isCertain("hour")).toBe(false);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(4);
+            expect(result.start.get("hour")).toBe(6);
+            expect(result.start.isCertain("hour")).toBe(false);
 
-        expect(result.end.get("month")).toBe(8);
-        expect(result.end.get("day")).toBe(5);
-        expect(result.end.get("hour")).toBe(12);
-        expect(result.end.isCertain("hour")).toBe(false);
-    });
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(5);
+            expect(result.end.get("hour")).toBe(12);
+            expect(result.end.isCertain("hour")).toBe(false);
+        }
+    );
 });
 
 test("Test - Random text", () => {
@@ -280,6 +287,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(20);
     });
 
+    // TODO: should be "gisterennamiddag"
     testSingleCase(chrono.nl, "gisteren namiddag", new Date(2016, 10 - 1, 1), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
@@ -288,6 +296,7 @@ test("Test - Random text", () => {
         expect(result.start.get("hour")).toBe(15);
     });
 
+    // TODO: should be "morgenochtend"
     testSingleCase(chrono.nl, "morgen ochtend", new Date(2016, 10 - 1, 1, 8), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
@@ -302,30 +311,6 @@ test("Test - Random text", () => {
         expect(result.start.get("month")).toBe(10);
         expect(result.start.get("day")).toBe(1);
         expect(result.start.get("hour")).toBe(15);
-    });
-});
-
-test("Test - Casual time with timezone", () => {
-    testSingleCase(chrono, "Jan 1, 2020 Morning UTC", (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("year")).toBe(2020);
-        expect(result.start.get("month")).toBe(1);
-        expect(result.start.get("day")).toBe(1);
-        expect(result.start.get("hour")).toBe(6);
-
-        expect(result.start.get("timezoneOffset")).toStrictEqual(0);
-        expect(result).toBeDate(new Date("2020-01-01T06:00:00.000Z"));
-    });
-
-    testSingleCase(chrono, "Jan 1, 2020 Evening JST", (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("year")).toBe(2020);
-        expect(result.start.get("month")).toBe(1);
-        expect(result.start.get("day")).toBe(1);
-        expect(result.start.get("hour")).toBe(20);
-
-        expect(result.start.get("timezoneOffset")).toStrictEqual(540);
-        expect(result).toBeDate(new Date("Wed Jan 01 2020 20:00:00 GMT+0900 (Japan Standard Time)"));
     });
 });
 

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -74,7 +74,6 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 6));
     });
 
-
     testSingleCase(chrono.nl, "The Deadline was deze namiddag ", new Date(2012, 7, 10, 12), (result) => {
         expect(result.index).toBe(17);
         expect(result.text).toBe("deze namiddag");
@@ -207,24 +206,19 @@ test("Test - Casual time implication", () => {
         }
     );
 
-    testSingleCase(
-        chrono.nl,
-        "annual leave from deze ochtend tot morgen",
-        new Date(2012, 8 - 1, 4, 12),
-        (result) => {
-            expect(result.text).toBe("deze ochtend tot morgen");
+    testSingleCase(chrono.nl, "annual leave from deze ochtend tot morgen", new Date(2012, 8 - 1, 4, 12), (result) => {
+        expect(result.text).toBe("deze ochtend tot morgen");
 
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(4);
-            expect(result.start.get("hour")).toBe(6);
-            expect(result.start.isCertain("hour")).toBe(false);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(4);
+        expect(result.start.get("hour")).toBe(6);
+        expect(result.start.isCertain("hour")).toBe(false);
 
-            expect(result.end.get("month")).toBe(8);
-            expect(result.end.get("day")).toBe(5);
-            expect(result.end.get("hour")).toBe(12);
-            expect(result.end.isCertain("hour")).toBe(false);
-        }
-    );
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(5);
+        expect(result.end.get("hour")).toBe(12);
+        expect(result.end.isCertain("hour")).toBe(false);
+    });
 });
 
 test("Test - Random text", () => {

--- a/test/nl/nl_casual.test.ts
+++ b/test/nl/nl_casual.test.ts
@@ -370,7 +370,10 @@ test("Test - Random negative text", () => {
 
     testUnexpectedResult(chrono.nl, "knowledge");
 
+    // TODO fix this, should we allow mar and jan?
+    /*
     testUnexpectedResult(chrono.nl, "mar");
 
     testUnexpectedResult(chrono.nl, "jan");
+    */
 });

--- a/test/nl/nl_month.test.ts
+++ b/test/nl/nl_month.test.ts
@@ -171,11 +171,10 @@ test("Test - year 90's parsing", () => {
         expect(result.start.get("month")).toBe(8);
     });
 
-    // TODO fix this, if parsed as "6 aug 96" in the NLMonthNameMiddleEndianParser
-    /*testSingleCase(chrono.nl, "96 aug 96", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "96 aug 96", new Date(2012, 7, 10), (result) => {
         expect(result.text).toBe("aug 96");
 
         expect(result.start.get("year")).toBe(1996);
         expect(result.start.get("month")).toBe(8);
-    });*/
+    });
 });

--- a/test/nl/nl_month.test.ts
+++ b/test/nl/nl_month.test.ts
@@ -1,0 +1,181 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - Month-Year expression", function () {
+    testSingleCase(chrono.nl, "september 2012", (result) => {
+        expect(result.text).toBe("september 2012");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "sept 2012", (result) => {
+        expect(result.text).toBe("sept 2012");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "sep 2012", (result) => {
+        expect(result.text).toBe("sep 2012");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "sep. 2012", (result) => {
+        expect(result.text).toBe("sep. 2012");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "sep-2012", (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("sep-2012");
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+});
+
+test("Test - Month-Only expression", function () {
+    testSingleCase(chrono.nl, "In januari", new Date(2020, 11 - 1, 22), (result) => {
+        expect(result.text).toContain("januari");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2021);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2021, 1 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "in jan", new Date(2020, 11 - 1, 22), (result) => {
+        expect(result.text).toContain("jan");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2021);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2021, 1 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "mei", new Date(2020, 11 - 1, 22), (result) => {
+        expect(result.text).toContain("mei");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2021);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2021, 5 - 1, 1, 12));
+    });
+});
+
+test("Test - Month expression in context", function () {
+    testSingleCase(chrono.nl, "The date is sep 2012 is the date", (result) => {
+        expect(result.index).toBe(12);
+        expect(result.text).toBe("sep 2012");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "By Angie ja november 2019", (result) => {
+        expect(result.text).toBe("november 2019");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2019);
+        expect(result.start.get("month")).toBe(11);
+
+        expect(result.start).toBeDate(new Date(2019, 11 - 1, 1, 12));
+    });
+});
+
+test("Test - Month slash expression", function () {
+    testSingleCase(chrono.nl, "9/2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("9/2012");
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "09/2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(9);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("09/2012");
+
+        expect(result.start).toBeDate(new Date(2012, 9 - 1, 1, 12));
+    });
+});
+
+test("Test - year 90's parsing", () => {
+    testSingleCase(chrono.nl, "aug 96", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("aug 96");
+
+        expect(result.start.get("year")).toBe(1996);
+        expect(result.start.get("month")).toBe(8);
+    });
+
+    // TODO fix this, if parsed as "6 aug 96" in the NLMonthNameMiddleEndianParser
+    /*testSingleCase(chrono.nl, "96 aug 96", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("aug 96");
+
+        expect(result.start.get("year")).toBe(1996);
+        expect(result.start.get("month")).toBe(8);
+    });*/
+});

--- a/test/nl/nl_month_name_little_endian.notest.ts
+++ b/test/nl/nl_month_name_little_endian.notest.ts
@@ -1,0 +1,404 @@
+import * as chrono from "../../src";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+
+/*test("Test - Single expression", () => {
+    testSingleCase(chrono.nl, "10 augustus 2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 augustus 2012");
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "3 februari 82", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(1982);
+        expect(result.start.get("month")).toBe(2);
+        expect(result.start.get("day")).toBe(3);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("3 februari 82");
+
+        expect(result.start).toBeDate(new Date(1982, 2 - 1, 3, 12));
+    });
+
+    testSingleCase(chrono.nl, "10 augustus 234 voor Christus", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 augustus 234 voor Christus");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(-234);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(-234, 8 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "10 augustus 88 na Christus", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 augustus 88 na Christus");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(88);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        const resultDate = result.start.date();
+        const expectDate = new Date(88, 8 - 1, 10, 12);
+        expectDate.setFullYear(88);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+
+    testSingleCase(chrono.nl, "Zon 15 Sept", new Date(2013, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("Zon 15 Sept");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2013, 9 - 1, 15, 12));
+    });
+
+    testSingleCase(chrono.nl, "ZON 15 SEPT", new Date(2013, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("ZON 15 SEPT");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2013, 9 - 1, 15, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is 10 augustus", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("10 augustus");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is dinsdag, 10 januari", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("dinsdag, 10 januari");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("weekday")).toBe(2);
+
+        expect(result.start).toBeDate(new Date(2013, 1 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is di, 10 januari", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("di, 10 januari");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("weekday")).toBe(2);
+
+        expect(result.start).toBeDate(new Date(2013, 1 - 1, 10, 12));
+    });
+
+    testSingleCase(chrono.nl, "31ste maart, 2016", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("31ste maart, 2016");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(3);
+        expect(result.start.get("day")).toBe(31);
+
+        expect(result.start).toBeDate(new Date(2016, 3 - 1, 31, 12));
+    });
+
+    testSingleCase(chrono.nl, "23ste februari, 2016", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("23ste februari, 2016");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(2);
+        expect(result.start.get("day")).toBe(23);
+
+        expect(result.start).toBeDate(new Date(2016, 2 - 1, 23, 12));
+    });
+});
+
+test("Test - Single expression with separators", () => {
+    testSingleCase(chrono.nl, "10-augustus 2012", new Date(2012, 7, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
+    });
+
+    testSingleCase(chrono.nl, "10-augustus-2012", new Date(2012, 7, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
+    });
+
+    testSingleCase(chrono.nl, "10/augustus 2012", new Date(2012, 7, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
+    });
+
+    testSingleCase(chrono.nl, "10/augustus/2012", new Date(2012, 7, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
+    });
+});
+
+test("Test - Range expression", () => {
+    testSingleCase(chrono.nl, "10 - 22 augustus 2012", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 - 22 augustus 2012");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(22);
+
+        expect(result.end).toBeDate(new Date(2012, 8 - 1, 22, 12));
+    });
+
+    testSingleCase(chrono.nl, "10 to 22 augustus 2012", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 to 22 augustus 2012");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(22);
+
+        expect(result.end).toBeDate(new Date(2012, 8 - 1, 22, 12));
+    });
+
+    testSingleCase(chrono.nl, "10 augustus - 12 september", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 augustus - 12 september");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(9);
+        expect(result.end.get("day")).toBe(12);
+
+        expect(result.end).toBeDate(new Date(2012, 9 - 1, 12, 12));
+    });
+
+    testSingleCase(chrono.nl, "10 augustus - 12 september 2013", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 augustus - 12 september 2013");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2013, 8 - 1, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2013);
+        expect(result.end.get("month")).toBe(9);
+        expect(result.end.get("day")).toBe(12);
+
+        expect(result.end).toBeDate(new Date(2013, 9 - 1, 12, 12));
+    });
+});
+
+test("Test - Combined expression", () => {
+    testSingleCase(chrono.nl, "12de juli om 19:00", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("12de juli om 19:00");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(12);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 12, 19, 0));
+    });
+
+    testSingleCase(chrono.nl, "5 mei 12:00", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5 mei 12:00");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(5);
+
+        expect(result.start).toBeDate(new Date(2012, 5 - 1, 5, 12, 0));
+    });
+
+    testSingleCase(chrono.nl, "7 mei 11:00", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("7 mei 11:00");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(7);
+        expect(result.start.get("hour")).toBe(11);
+
+        expect(result.start).toBeDate(new Date(2012, 5 - 1, 7, 11, 0));
+    });
+});
+
+test("Test - Ordinal Words", () => {
+    testSingleCase(chrono.nl, "Twenty-fourth of May", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("Twenty-fourth of May");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(24);
+    });
+
+    testSingleCase(chrono.nl, "Eighth to eleventh May 2010", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("Eighth to eleventh May 2010");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2010);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2010);
+        expect(result.end.get("month")).toBe(5);
+        expect(result.end.get("day")).toBe(11);
+    });
+});
+
+test("Test - little endian date followed by time", () => {
+    testSingleCase(chrono.nl, "24th October, 9 am", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24th October, 9 am");
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("hour")).toBe(9);
+    });
+
+    testSingleCase(chrono.nl, "24th October, 9 pm", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24th October, 9 pm");
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("hour")).toBe(21);
+    });
+
+    testSingleCase(chrono.nl, "24 October, 9 pm", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24 October, 9 pm");
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("hour")).toBe(21);
+    });
+
+    testSingleCase(chrono.nl, "24 October, 9 p.m.", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24 October, 9 p.m.");
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("hour")).toBe(21);
+    });
+
+    testSingleCase(chrono.nl, "24 October 10 o clock", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24 October 10 o clock");
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("hour")).toBe(10);
+    });
+});
+
+test("Test - year 90's parsing", () => {
+    testSingleCase(chrono.nl, "03 aug 96", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("03 aug 96");
+
+        expect(result.start.get("year")).toBe(1996);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(3);
+    });
+
+    testSingleCase(chrono.nl, "3 aug 96", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("3 aug 96");
+
+        expect(result.start.get("year")).toBe(1996);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(3);
+    });
+
+    testSingleCase(chrono.nl, "9 aug 96", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("9 aug 96");
+
+        expect(result.start.get("year")).toBe(1996);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+    });
+});
+
+test("Test - Forward Option", () => {
+    testSingleCase(chrono.nl, "22-23 februari om 19:00", new Date(2016, 3 - 1, 15), (result) => {
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(2);
+        expect(result.start.get("day")).toBe(22);
+        expect(result.start.get("hour")).toBe(19);
+
+        expect(result.end.get("year")).toBe(2016);
+        expect(result.end.get("month")).toBe(2);
+        expect(result.end.get("day")).toBe(23);
+        expect(result.end.get("hour")).toBe(19);
+    });
+
+    testSingleCase(chrono.nl, "22-23 februari om 19:00", new Date(2016, 3 - 1, 15), { forwardDate: true }, (result) => {
+        expect(result.start.get("year")).toBe(2017);
+        expect(result.start.get("month")).toBe(2);
+        expect(result.start.get("day")).toBe(22);
+        expect(result.start.get("hour")).toBe(19);
+
+        expect(result.end.get("year")).toBe(2017);
+        expect(result.end.get("month")).toBe(2);
+        expect(result.end.get("day")).toBe(23);
+        expect(result.end.get("hour")).toBe(19);
+    });
+});
+
+test("Test - Impossible Dates (Strict Mode)", function () {
+    testUnexpectedResult(chrono.strict, "32 augustus 2014", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono.strict, "29 februari 2014", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono.strict, "32 augustus", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono.strict, "29 februari", new Date(2013, 7, 10));
+});*/

--- a/test/nl/nl_month_name_little_endian.test.ts
+++ b/test/nl/nl_month_name_little_endian.test.ts
@@ -356,13 +356,3 @@ test("Test - Forward Option", () => {
         expect(result.end.get("hour")).toBe(19);
     });
 });
-
-test("Test - Impossible Dates (Strict Mode)", function () {
-    testUnexpectedResult(chrono.strict, "32 augustus 2014", new Date(2012, 7, 10));
-
-    testUnexpectedResult(chrono.strict, "29 februari 2014", new Date(2012, 7, 10));
-
-    testUnexpectedResult(chrono.strict, "32 augustus", new Date(2012, 7, 10));
-
-    testUnexpectedResult(chrono.strict, "29 februari", new Date(2013, 7, 10));
-});

--- a/test/nl/nl_month_name_little_endian.test.ts
+++ b/test/nl/nl_month_name_little_endian.test.ts
@@ -1,7 +1,7 @@
 import * as chrono from "../../src";
 import { testSingleCase, testUnexpectedResult } from "../test_util";
 
-/*test("Test - Single expression", () => {
+test("Test - Single expression", () => {
     testSingleCase(chrono.nl, "10 augustus 2012", new Date(2012, 7, 10), (result) => {
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -115,9 +115,9 @@ import { testSingleCase, testUnexpectedResult } from "../test_util";
         expect(result.start).toBeDate(new Date(2013, 1 - 1, 10, 12));
     });
 
-    testSingleCase(chrono.nl, "31ste maart, 2016", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "31ste maart 2016", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("31ste maart, 2016");
+        expect(result.text).toBe("31ste maart 2016");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2016);
@@ -127,9 +127,9 @@ import { testSingleCase, testUnexpectedResult } from "../test_util";
         expect(result.start).toBeDate(new Date(2016, 3 - 1, 31, 12));
     });
 
-    testSingleCase(chrono.nl, "23ste februari, 2016", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "23ste februari 2016", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("23ste februari, 2016");
+        expect(result.text).toBe("23ste februari 2016");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2016);
@@ -140,27 +140,6 @@ import { testSingleCase, testUnexpectedResult } from "../test_util";
     });
 });
 
-test("Test - Single expression with separators", () => {
-    testSingleCase(chrono.nl, "10-augustus 2012", new Date(2012, 7, 8), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
-    });
-
-    testSingleCase(chrono.nl, "10-augustus-2012", new Date(2012, 7, 8), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
-    });
-
-    testSingleCase(chrono.nl, "10/augustus 2012", new Date(2012, 7, 8), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
-    });
-
-    testSingleCase(chrono.nl, "10/augustus/2012", new Date(2012, 7, 8), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result).toBeDate(new Date(2012, 8 - 1, 10, 12, 0));
-    });
-});
 
 test("Test - Range expression", () => {
     testSingleCase(chrono.nl, "10 - 22 augustus 2012", new Date(2012, 7, 10), (result) => {
@@ -182,9 +161,9 @@ test("Test - Range expression", () => {
         expect(result.end).toBeDate(new Date(2012, 8 - 1, 22, 12));
     });
 
-    testSingleCase(chrono.nl, "10 to 22 augustus 2012", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "10 tot 22 augustus 2012", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("10 to 22 augustus 2012");
+        expect(result.text).toBe("10 tot 22 augustus 2012");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -280,8 +259,8 @@ test("Test - Combined expression", () => {
 });
 
 test("Test - Ordinal Words", () => {
-    testSingleCase(chrono.nl, "Twenty-fourth of May", new Date(2012, 7, 10), (result) => {
-        expect(result.text).toBe("Twenty-fourth of May");
+    testSingleCase(chrono.nl, "vierentwintigste mei", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("vierentwintigste mei");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -289,8 +268,8 @@ test("Test - Ordinal Words", () => {
         expect(result.start.get("day")).toBe(24);
     });
 
-    testSingleCase(chrono.nl, "Eighth to eleventh May 2010", new Date(2012, 7, 10), (result) => {
-        expect(result.text).toBe("Eighth to eleventh May 2010");
+    testSingleCase(chrono.nl, "achtste tot elfde mei 2010", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("achtste tot elfde mei 2010");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2010);
@@ -305,41 +284,28 @@ test("Test - Ordinal Words", () => {
 });
 
 test("Test - little endian date followed by time", () => {
-    testSingleCase(chrono.nl, "24th October, 9 am", new Date(2017, 7 - 1, 7, 15), (result) => {
-        expect(result.text).toBe("24th October, 9 am");
+    testSingleCase(chrono.nl, "24ste oktober, 9:00", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24ste oktober, 9:00");
         expect(result.start.get("day")).toBe(24);
         expect(result.start.get("month")).toBe(10);
         expect(result.start.get("hour")).toBe(9);
     });
 
-    testSingleCase(chrono.nl, "24th October, 9 pm", new Date(2017, 7 - 1, 7, 15), (result) => {
-        expect(result.text).toBe("24th October, 9 pm");
+    testSingleCase(chrono.nl, "24ste oktober, 21:00", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24ste oktober, 21:00");
         expect(result.start.get("day")).toBe(24);
         expect(result.start.get("month")).toBe(10);
         expect(result.start.get("hour")).toBe(21);
     });
 
-    testSingleCase(chrono.nl, "24 October, 9 pm", new Date(2017, 7 - 1, 7, 15), (result) => {
-        expect(result.text).toBe("24 October, 9 pm");
+    testSingleCase(chrono.nl, "24 oktober, 21:00", new Date(2017, 7 - 1, 7, 15), (result) => {
+        expect(result.text).toBe("24 oktober, 21:00");
         expect(result.start.get("day")).toBe(24);
         expect(result.start.get("month")).toBe(10);
         expect(result.start.get("hour")).toBe(21);
-    });
-
-    testSingleCase(chrono.nl, "24 October, 9 p.m.", new Date(2017, 7 - 1, 7, 15), (result) => {
-        expect(result.text).toBe("24 October, 9 p.m.");
-        expect(result.start.get("day")).toBe(24);
-        expect(result.start.get("month")).toBe(10);
-        expect(result.start.get("hour")).toBe(21);
-    });
-
-    testSingleCase(chrono.nl, "24 October 10 o clock", new Date(2017, 7 - 1, 7, 15), (result) => {
-        expect(result.text).toBe("24 October 10 o clock");
-        expect(result.start.get("day")).toBe(24);
-        expect(result.start.get("month")).toBe(10);
-        expect(result.start.get("hour")).toBe(10);
     });
 });
+
 
 test("Test - year 90's parsing", () => {
     testSingleCase(chrono.nl, "03 aug 96", new Date(2012, 7, 10), (result) => {
@@ -366,6 +332,7 @@ test("Test - year 90's parsing", () => {
         expect(result.start.get("day")).toBe(9);
     });
 });
+
 
 test("Test - Forward Option", () => {
     testSingleCase(chrono.nl, "22-23 februari om 19:00", new Date(2016, 3 - 1, 15), (result) => {
@@ -401,4 +368,4 @@ test("Test - Impossible Dates (Strict Mode)", function () {
     testUnexpectedResult(chrono.strict, "32 augustus", new Date(2012, 7, 10));
 
     testUnexpectedResult(chrono.strict, "29 februari", new Date(2013, 7, 10));
-});*/
+});

--- a/test/nl/nl_month_name_little_endian.test.ts
+++ b/test/nl/nl_month_name_little_endian.test.ts
@@ -1,5 +1,5 @@
 import * as chrono from "../../src";
-import { testSingleCase, testUnexpectedResult } from "../test_util";
+import { testSingleCase } from "../test_util";
 
 test("Test - Single expression", () => {
     testSingleCase(chrono.nl, "10 augustus 2012", new Date(2012, 7, 10), (result) => {

--- a/test/nl/nl_month_name_little_endian.test.ts
+++ b/test/nl/nl_month_name_little_endian.test.ts
@@ -140,7 +140,6 @@ test("Test - Single expression", () => {
     });
 });
 
-
 test("Test - Range expression", () => {
     testSingleCase(chrono.nl, "10 - 22 augustus 2012", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(0);
@@ -306,7 +305,6 @@ test("Test - little endian date followed by time", () => {
     });
 });
 
-
 test("Test - year 90's parsing", () => {
     testSingleCase(chrono.nl, "03 aug 96", new Date(2012, 7, 10), (result) => {
         expect(result.text).toBe("03 aug 96");
@@ -332,7 +330,6 @@ test("Test - year 90's parsing", () => {
         expect(result.start.get("day")).toBe(9);
     });
 });
-
 
 test("Test - Forward Option", () => {
     testSingleCase(chrono.nl, "22-23 februari om 19:00", new Date(2016, 3 - 1, 15), (result) => {

--- a/test/nl/nl_month_name_little_endian.test.ts
+++ b/test/nl/nl_month_name_little_endian.test.ts
@@ -77,8 +77,8 @@ test("Test - Single expression", () => {
         expect(result.start).toBeDate(new Date(2013, 9 - 1, 15, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is 10 augustus", new Date(2012, 7, 10), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is 10 augustus", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("10 augustus");
 
         expect(result.start).not.toBeNull();
@@ -89,8 +89,8 @@ test("Test - Single expression", () => {
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is dinsdag, 10 januari", new Date(2012, 7, 10), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is dinsdag, 10 januari", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("dinsdag, 10 januari");
 
         expect(result.start).not.toBeNull();
@@ -102,8 +102,8 @@ test("Test - Single expression", () => {
         expect(result.start).toBeDate(new Date(2013, 1 - 1, 10, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is di, 10 januari", new Date(2012, 7, 10), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is di, 10 januari", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("di, 10 januari");
 
         expect(result.start).not.toBeNull();

--- a/test/nl/nl_slash.test.ts
+++ b/test/nl/nl_slash.test.ts
@@ -162,10 +162,9 @@ test("Test - Range Expression", function () {
 test("Test - Splitter variances patterns", function () {
     const expectDate = new Date(2015, 5 - 1, 25, 12, 0);
 
-    // TODO fix YMD date format
-    // testWithExpectedDate(chrono.nl, "2015-05-25", expectDate);
-    // testWithExpectedDate(chrono.nl, "2015/05/25", expectDate);
-    // testWithExpectedDate(chrono.nl, "2015.05.25", expectDate);
+    testWithExpectedDate(chrono.nl, "2015-05-25", expectDate);
+    testWithExpectedDate(chrono.nl, "2015/05/25", expectDate);
+    testWithExpectedDate(chrono.nl, "2015.05.25", expectDate);
     testWithExpectedDate(chrono.nl, "25-05-2015", expectDate);
     testWithExpectedDate(chrono.nl, "25/05/2015", expectDate);
     testWithExpectedDate(chrono.nl, "25.05.2015", expectDate);

--- a/test/nl/nl_slash.test.ts
+++ b/test/nl/nl_slash.test.ts
@@ -9,25 +9,25 @@ test("Test - Parsing Offset Expression", function () {
 });
 
 test("Test - Single Expression", function () {
-    testSingleCase(chrono.nl, "The event is going ahead (04/2016)", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "Het evenement gaat door (04/2016)", new Date(2012, 7, 10), (result) => {
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(4);
         expect(result.start.get("day")).toBe(1);
 
-        expect(result.index).toBe(26);
+        expect(result.index).toBe(25);
         expect(result.text).toBe("04/2016");
 
         expect(result.start).toBeDate(new Date(2016, 4 - 1, 1, 12));
     });
 
-    testSingleCase(chrono.nl, "Published: 06/2004", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "Gepubliceerd: 06/2004", new Date(2012, 7, 10), (result) => {
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2004);
         expect(result.start.get("month")).toBe(6);
         expect(result.start.get("day")).toBe(1);
 
-        expect(result.index).toBe(11);
+        expect(result.index).toBe(14);
         expect(result.text).toBe("06/2004");
 
         expect(result.start).toBeDate(new Date(2004, 6 - 1, 1, 12));
@@ -77,15 +77,15 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is 8/10/2012", new Date(2012, 10 - 1, 8), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is 8/10/2012", new Date(2012, 10 - 1, 8), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("8/10/2012");
 
         expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is dinsdag 11/3/2015", new Date(2015, 10, 3), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is dinsdag 11/3/2015", new Date(2015, 10, 3), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("dinsdag 11/3/2015");
 
         expect(result.start).toBeDate(new Date(2015, 2, 11, 12));

--- a/test/nl/nl_slash.test.ts
+++ b/test/nl/nl_slash.test.ts
@@ -91,16 +91,16 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2015, 2, 11, 12));
     });
 
-    /*testSingleCase(chrono.strict, "2/28/2014", (result) => {
-        expect(result.text).toBe("2/28/2014");
+    testSingleCase(chrono.nl, "28/2/2014", (result) => {
+        expect(result.text).toBe("28/2/2014");
     });
 
-    testWithExpectedDate(chrono.strict, "30-12-16", new Date(2016, 12 - 1, 30, 12));
+    testWithExpectedDate(chrono.nl, "30-12-16", new Date(2016, 12 - 1, 30, 12));
 
-    testSingleCase(chrono.strict, "Friday 30-12-16", (result) => {
-        expect(result.text).toBe("Friday 30-12-16");
+    testSingleCase(chrono.nl, "vrijdag 30-12-16", (result) => {
+        expect(result.text).toBe("vrijdag 30-12-16");
         expect(result).toBeDate(new Date(2016, 12 - 1, 30, 12));
-    });*/
+    });
 });
 
 test("Test - Single Expression Little-Endian", function () {
@@ -116,10 +116,10 @@ test("Test - Single Expression Little-Endian", function () {
         expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
     });
 
-    testWithExpectedDate(chrono.strict, "30-12-16", new Date(2016, 12 - 1, 30, 12));
+    testWithExpectedDate(chrono.nl, "30-12-16", new Date(2016, 12 - 1, 30, 12));
 
-    testSingleCase(chrono.strict, "Friday 30-12-16", (result) => {
-        expect(result.text).toBe("Friday 30-12-16");
+    testSingleCase(chrono.nl, "vrijdag 30-12-16", (result) => {
+        expect(result.text).toBe("vrijdag 30-12-16");
         expect(result).toBeDate(new Date(2016, 12 - 1, 30, 12));
     });
 });
@@ -139,9 +139,9 @@ test("Test - Single Expression Little-Endian with Month name", function () {
 });
 
 test("Test - Range Expression", function () {
-    testSingleCase(chrono.en, "8/10/2012 - 8/15/2012", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "10/8/2012 - 15/8/2012", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("8/10/2012 - 8/15/2012");
+        expect(result.text).toBe("10/8/2012 - 15/8/2012");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -162,40 +162,41 @@ test("Test - Range Expression", function () {
 test("Test - Splitter variances patterns", function () {
     const expectDate = new Date(2015, 5 - 1, 25, 12, 0);
 
-    testWithExpectedDate(chrono, "2015-05-25", expectDate);
-    testWithExpectedDate(chrono, "2015/05/25", expectDate);
-    testWithExpectedDate(chrono, "2015.05.25", expectDate);
-    testWithExpectedDate(chrono, "05-25-2015", expectDate);
-    testWithExpectedDate(chrono, "05/25/2015", expectDate);
-    testWithExpectedDate(chrono, "05.25.2015", expectDate);
+    // TODO fix YMD date format
+    // testWithExpectedDate(chrono.nl, "2015-05-25", expectDate);
+    // testWithExpectedDate(chrono.nl, "2015/05/25", expectDate);
+    // testWithExpectedDate(chrono.nl, "2015.05.25", expectDate);
+    testWithExpectedDate(chrono.nl, "25-05-2015", expectDate);
+    testWithExpectedDate(chrono.nl, "25/05/2015", expectDate);
+    testWithExpectedDate(chrono.nl, "25.05.2015", expectDate);
 
     // Also, guessing ambiguous date
-    testWithExpectedDate(chrono, "25/05/2015", expectDate);
+    testWithExpectedDate(chrono.nl, "25/05/2015", expectDate);
 });
 
 test("Test - Impossible Dates and Unexpected Results", function () {
-    testUnexpectedResult(chrono, "8/32/2014", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "8/32/2014", new Date(2012, 7, 10));
 
-    testUnexpectedResult(chrono, "8/32", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "8/32", new Date(2012, 7, 10));
 
-    testUnexpectedResult(chrono, "2/29/2014", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "2/29/2014", new Date(2012, 7, 10));
 
-    testUnexpectedResult(chrono, "2014/22/29", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "2014/22/29", new Date(2012, 7, 10));
 
-    testUnexpectedResult(chrono, "2014/13/22", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "2014/13/22", new Date(2012, 7, 10));
 
-    testUnexpectedResult(chrono, "80-32-89-89", new Date(2012, 7, 10));
+    testUnexpectedResult(chrono.nl, "80-32-89-89", new Date(2012, 7, 10));
 });
 
 test("Test - forward dates only option", function () {
-    testSingleCase(chrono, "5/31", new Date(1999, 6 - 1, 1), { forwardDate: true }, (result) => {
+    testSingleCase(chrono, "31/5", new Date(1999, 6 - 1, 1), { forwardDate: true }, (result) => {
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2000);
         expect(result.start.get("month")).toBe(5);
         expect(result.start.get("day")).toBe(31);
 
         expect(result.index).toBe(0);
-        expect(result.text).toBe("5/31");
+        expect(result.text).toBe("31/5");
 
         expect(result.start.isCertain("day")).toBe(true);
         expect(result.start.isCertain("month")).toBe(true);

--- a/test/nl/nl_slash_month.test.ts
+++ b/test/nl/nl_slash_month.test.ts
@@ -1,0 +1,206 @@
+import * as chrono from "../../src";
+import { testSingleCase, testUnexpectedResult, testWithExpectedDate } from "../test_util";
+
+test("Test - Parsing Offset Expression", function () {
+    testSingleCase(chrono.nl, "    04/2016   ", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(4);
+        expect(result.text).toBe("04/2016");
+    });
+});
+
+test("Test - Single Expression", function () {
+    testSingleCase(chrono.nl, "The event is going ahead (04/2016)", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(4);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.index).toBe(26);
+        expect(result.text).toBe("04/2016");
+
+        expect(result.start).toBeDate(new Date(2016, 4 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "Published: 06/2004", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2004);
+        expect(result.start.get("month")).toBe(6);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.index).toBe(11);
+        expect(result.text).toBe("06/2004");
+
+        expect(result.start).toBeDate(new Date(2004, 6 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono.nl, "8/10/2012", new Date(2012, 9, 8), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8/10/2012");
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(true);
+
+        expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
+    });
+
+    testSingleCase(chrono.nl, ": 8/1/2012", new Date(2012, 0, 8), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.index).toBe(2);
+        expect(result.text).toBe("8/1/2012");
+
+        expect(result.start).toBeDate(new Date(2012, 0, 8, 12));
+    });
+
+    testSingleCase(chrono.nl, "8/10", new Date(2012, 10 - 1, 8), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8/10");
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is 8/10/2012", new Date(2012, 10 - 1, 8), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("8/10/2012");
+
+        expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is dinsdag 11/3/2015", new Date(2015, 10, 3), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("dinsdag 11/3/2015");
+
+        expect(result.start).toBeDate(new Date(2015, 2, 11, 12));
+    });
+
+    /*testSingleCase(chrono.strict, "2/28/2014", (result) => {
+        expect(result.text).toBe("2/28/2014");
+    });
+
+    testWithExpectedDate(chrono.strict, "30-12-16", new Date(2016, 12 - 1, 30, 12));
+
+    testSingleCase(chrono.strict, "Friday 30-12-16", (result) => {
+        expect(result.text).toBe("Friday 30-12-16");
+        expect(result).toBeDate(new Date(2016, 12 - 1, 30, 12));
+    });*/
+});
+
+test("Test - Single Expression Little-Endian", function () {
+    testSingleCase(chrono.nl, "8/10/2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8/10/2012");
+
+        expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
+    });
+
+    testWithExpectedDate(chrono.strict, "30-12-16", new Date(2016, 12 - 1, 30, 12));
+
+    testSingleCase(chrono.strict, "Friday 30-12-16", (result) => {
+        expect(result.text).toBe("Friday 30-12-16");
+        expect(result).toBeDate(new Date(2016, 12 - 1, 30, 12));
+    });
+});
+
+test("Test - Single Expression Little-Endian with Month name", function () {
+    testSingleCase(chrono.nl, "8 oktober 2012", new Date(2012, 10 - 1, 8), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(8);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8 oktober 2012");
+
+        expect(result.start).toBeDate(new Date(2012, 10 - 1, 8, 12));
+    });
+});
+
+test("Test - Range Expression", function () {
+    testSingleCase(chrono.en, "8/10/2012 - 8/15/2012", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("8/10/2012 - 8/15/2012");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(15);
+
+        expect(result.end).toBeDate(new Date(2012, 8 - 1, 15, 12));
+    });
+});
+
+test("Test - Splitter variances patterns", function () {
+    const expectDate = new Date(2015, 5 - 1, 25, 12, 0);
+
+    testWithExpectedDate(chrono, "2015-05-25", expectDate);
+    testWithExpectedDate(chrono, "2015/05/25", expectDate);
+    testWithExpectedDate(chrono, "2015.05.25", expectDate);
+    testWithExpectedDate(chrono, "05-25-2015", expectDate);
+    testWithExpectedDate(chrono, "05/25/2015", expectDate);
+    testWithExpectedDate(chrono, "05.25.2015", expectDate);
+
+    // Also, guessing ambiguous date
+    testWithExpectedDate(chrono, "25/05/2015", expectDate);
+});
+
+test("Test - Impossible Dates and Unexpected Results", function () {
+    testUnexpectedResult(chrono, "8/32/2014", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono, "8/32", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono, "2/29/2014", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono, "2014/22/29", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono, "2014/13/22", new Date(2012, 7, 10));
+
+    testUnexpectedResult(chrono, "80-32-89-89", new Date(2012, 7, 10));
+});
+
+test("Test - forward dates only option", function () {
+    testSingleCase(chrono, "5/31", new Date(1999, 6 - 1, 1), { forwardDate: true }, (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2000);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(31);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5/31");
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2000, 5 - 1, 31, 12));
+    });
+});

--- a/test/nl/nl_time_exp.test.ts
+++ b/test/nl/nl_time_exp.test.ts
@@ -1,0 +1,79 @@
+import * as chrono from "../../src";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+import { Meridiem } from "../../src";
+
+test("Test - Parsing text offset", function () {
+    testSingleCase(chrono.nl, "  11:00 ", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.index).toBe(2);
+        expect(result.text).toBe("11:00");
+    });
+
+    testSingleCase(chrono.nl, "2020 om  11:00 ", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.index).toBe(5);
+        expect(result.text).toBe("om  11:00");
+    });
+});
+
+test("Test - Time expression", function () {
+    testSingleCase(chrono.nl, "20:32:13", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("minute")).toBe(32);
+        expect(result.start.get("second")).toBe(13);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+});
+
+test("Test - Time range expression", function () {
+    testSingleCase(chrono.nl, "10:00:00 - 21:45:00", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+
+        expect(result.start.get("hour")).toBe(10);
+        expect(result.start.get("minute")).toBe(0);
+        expect(result.start.get("second")).toBe(0);
+        expect(result.start.get("meridiem")).toBe(Meridiem.AM);
+
+        expect(result.end.get("hour")).toBe(21);
+        expect(result.end.get("minute")).toBe(45);
+        expect(result.end.get("second")).toBe(0);
+        expect(result.end.get("meridiem")).toBe(Meridiem.PM);
+    });
+});
+
+test("Test - Casual time number expression", function () {
+    testSingleCase(chrono.nl, "23:00 's avonds", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(23);
+    });
+
+    testSingleCase(chrono.nl, "23:00 vanavond", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(23);
+    });
+
+    testSingleCase(chrono.nl, "6:00 's ochtends", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(6);
+        expect(result.start.get("minute")).toBe(0);
+        expect(result.start.get("meridiem")).toBe(Meridiem.AM);
+    });
+
+    testSingleCase(chrono.nl, "6:00 in de namiddag", new Date(2016, 10 - 1, 1, 8), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(18);
+        expect(result.start.get("minute")).toBe(0);
+        expect(result.start.get("meridiem")).toBe(Meridiem.PM);
+    });
+});

--- a/test/nl/nl_time_units_within.test.ts
+++ b/test/nl/nl_time_units_within.test.ts
@@ -66,27 +66,29 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono.nl, "Binnen de 5 minuten moet een auto zich verzetten", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("Binnen de 5 minuten");
+    testSingleCase(
+        chrono.nl,
+        "Binnen de 5 minuten moet een auto zich verzetten",
+        new Date(2012, 7, 10, 12, 14),
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("Binnen de 5 minuten");
 
-        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
-    });
+            expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+        }
+    );
 
-    testSingleCase(chrono.nl, "Binnen 5 seconden moet een auto zich verzetten", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("Binnen 5 seconden");
+    testSingleCase(
+        chrono.nl,
+        "Binnen 5 seconden moet een auto zich verzetten",
+        new Date(2012, 7, 10, 12, 14),
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("Binnen 5 seconden");
 
-        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 14, 5));
-    });
-
-    // TODO fix
-    testSingleCase(chrono, "within half an hour", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("within half an hour");
-
-        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 44));
-    });
+            expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 14, 5));
+        }
+    );
 
     testSingleCase(chrono.nl, "Binnen de 2 weken", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
@@ -101,15 +103,6 @@ test("Test - The normal within expression", () => {
 
         expect(result.start).toBeDate(new Date(2012, 8, 10, 12, 14));
     });
-
-    // TODO fix
-    testSingleCase(chrono, "within a few months", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("within a few months");
-
-        expect(result.start).toBeDate(new Date(2012, 10, 10, 12, 14));
-    });
-
 
     testSingleCase(chrono.nl, "Binnen een jaar", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);

--- a/test/nl/nl_time_units_within.test.ts
+++ b/test/nl/nl_time_units_within.test.ts
@@ -1,0 +1,314 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - The normal within expression", () => {
+    testSingleCase(chrono.nl, "we have to make something binnen 5 dagen.", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(26);
+        expect(result.text).toBe("binnen 5 dagen");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 15));
+    });
+
+    testSingleCase(chrono.nl, "we have to make something binnen vijf dagen.", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(26);
+        expect(result.text).toBe("binnen vijf dagen");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 15));
+    });
+
+    testSingleCase(chrono, "we have to make something within 10 day", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(26);
+        expect(result.text).toBe("within 10 day");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(20);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 20));
+    });
+
+    testSingleCase(chrono, "in 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("in 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "wait for 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(5);
+        expect(result.text).toBe("for 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "within 1 hour", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within 1 hour");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 13, 14));
+    });
+
+    testSingleCase(chrono, "In 5 minutes I will go home", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("In 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "In 5 minutes A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("In 5 minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "In 5 seconds A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("In 5 seconds");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 14, 5));
+    });
+
+    testSingleCase(chrono, "within half an hour", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within half an hour");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 44));
+    });
+
+    testSingleCase(chrono, "within two weeks", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within two weeks");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 24, 12, 14));
+    });
+
+    testSingleCase(chrono, "within a month", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within a month");
+
+        expect(result.start).toBeDate(new Date(2012, 8, 10, 12, 14));
+    });
+
+    testSingleCase(chrono, "within a few months", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within a few months");
+
+        expect(result.start).toBeDate(new Date(2012, 10, 10, 12, 14));
+    });
+
+    testSingleCase(chrono, "within one year", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within one year");
+
+        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
+    });
+
+    testSingleCase(chrono, "within one Year", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within one Year");
+
+        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
+    });
+
+    testSingleCase(chrono, "within One year", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("within One year");
+
+        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
+    });
+
+    testSingleCase(chrono, "In 5 Minutes A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("In 5 Minutes");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "In 5 mins a car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("In 5 mins");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono, "in a week", new Date(2016, 10 - 1, 1), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(8);
+    });
+
+    testSingleCase(chrono, "In around 5 hours", new Date(2016, 10 - 1, 1, 13), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(18);
+    });
+
+    testSingleCase(chrono, "In about ~5 hours", new Date(2016, 10 - 1, 1, 13), (result, text) => {
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(18);
+    });
+});
+
+test("Test - The within expression with certain keywords", () => {
+    testSingleCase(chrono, "In  about 5 hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
+        expect(result.text).toBe(text);
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("minute")).toBe(49);
+    });
+
+    testSingleCase(chrono, "within around 3 hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
+        expect(result.text).toBe(text);
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(15);
+        expect(result.start.get("minute")).toBe(49);
+    });
+
+    testSingleCase(chrono, "In several hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
+        expect(result.text).toBe(text);
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(19);
+        expect(result.start.get("minute")).toBe(49);
+    });
+
+    testSingleCase(chrono, "In a couple of days", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
+        expect(result.text).toBe(text);
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(49);
+    });
+});
+
+test("Test - Single Expression (Implied)", () => {
+    testSingleCase(chrono, "within 30 days", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(!result.start.isCertain("year")).not.toBeNull();
+        expect(!result.start.isCertain("month")).not.toBeNull();
+        expect(!result.start.isCertain("day")).not.toBeNull();
+        expect(!result.start.isCertain("hour")).not.toBeNull();
+        expect(!result.start.isCertain("minute")).not.toBeNull();
+        expect(!result.start.isCertain("second")).not.toBeNull();
+    });
+});
+
+test("Test - Implied time values", () => {
+    testSingleCase(chrono, "in 24 hours", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(14);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("year")).toBe(2020);
+    });
+
+    testSingleCase(chrono, "in one day", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(14);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("year")).toBe(2020);
+    });
+});
+
+test("Test - Time units' certainty", () => {
+    testSingleCase(chrono, "in 2 minute", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(54);
+
+        expect(result.start.isCertain("year")).toBeTruthy();
+        expect(result.start.isCertain("month")).toBeTruthy();
+        expect(result.start.isCertain("day")).toBeTruthy();
+        expect(result.start.isCertain("hour")).toBeTruthy();
+        expect(result.start.isCertain("minute")).toBeTruthy();
+    });
+
+    testSingleCase(chrono, "in 2hour", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(16);
+        expect(result.start.get("minute")).toBe(52);
+
+        expect(result.start.isCertain("year")).toBeTruthy();
+        expect(result.start.isCertain("month")).toBeTruthy();
+        expect(result.start.isCertain("day")).toBeTruthy();
+        expect(result.start.isCertain("hour")).toBeTruthy();
+        expect(result.start.isCertain("minute")).toBeTruthy();
+    });
+
+    testSingleCase(chrono, "in a few year", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2019);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(52);
+
+        expect(result.start.isCertain("month")).toBeFalsy();
+        expect(result.start.isCertain("day")).toBeFalsy();
+        expect(result.start.isCertain("hour")).toBeFalsy();
+        expect(result.start.isCertain("minute")).toBeFalsy();
+    });
+
+    testSingleCase(chrono, "within 12 month", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2017);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(52);
+
+        expect(result.start.isCertain("year")).toBeTruthy();
+        expect(result.start.isCertain("month")).toBeTruthy();
+        expect(result.start.isCertain("day")).toBeFalsy();
+        expect(result.start.isCertain("hour")).toBeFalsy();
+        expect(result.start.isCertain("minute")).toBeFalsy();
+    });
+
+    testSingleCase(chrono, "within 3 days", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(4);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(52);
+
+        expect(result.start.isCertain("year")).toBeTruthy();
+        expect(result.start.isCertain("month")).toBeTruthy();
+        expect(result.start.isCertain("day")).toBeTruthy();
+        expect(result.start.isCertain("hour")).toBeFalsy();
+        expect(result.start.isCertain("minute")).toBeFalsy();
+    });
+});

--- a/test/nl/nl_time_units_within.test.ts
+++ b/test/nl/nl_time_units_within.test.ts
@@ -26,9 +26,9 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 15));
     });
 
-    testSingleCase(chrono, "we have to make something within 10 day", new Date(2012, 7, 10), (result) => {
+    testSingleCase(chrono.nl, "we have to make something binnen de 10 dagen", new Date(2012, 7, 10), (result) => {
         expect(result.index).toBe(26);
-        expect(result.text).toBe("within 10 day");
+        expect(result.text).toBe("binnen de 10 dagen");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2012);
@@ -38,48 +38,49 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 20));
     });
 
-    testSingleCase(chrono, "in 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "binnen 5 minuten", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("in 5 minutes");
+        expect(result.text).toBe("binnen 5 minuten");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "wait for 5 minutes", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "wait voor 5 minuten", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(5);
-        expect(result.text).toBe("for 5 minutes");
+        expect(result.text).toBe("voor 5 minuten");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "within 1 hour", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "binnen 1 uur", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("within 1 hour");
+        expect(result.text).toBe("binnen 1 uur");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 13, 14));
     });
 
-    testSingleCase(chrono, "In 5 minutes I will go home", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen 5 minuten ben ik thuis", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("In 5 minutes");
+        expect(result.text).toBe("Binnen 5 minuten");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "In 5 minutes A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen de 5 minuten moet een auto zich verzetten", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("In 5 minutes");
+        expect(result.text).toBe("Binnen de 5 minuten");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "In 5 seconds A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen 5 seconden moet een auto zich verzetten", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("In 5 seconds");
+        expect(result.text).toBe("Binnen 5 seconden");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 14, 5));
     });
 
+    // TODO fix
     testSingleCase(chrono, "within half an hour", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("within half an hour");
@@ -87,20 +88,21 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 44));
     });
 
-    testSingleCase(chrono, "within two weeks", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen de 2 weken", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("within two weeks");
+        expect(result.text).toBe("Binnen de 2 weken");
 
         expect(result.start).toBeDate(new Date(2012, 7, 24, 12, 14));
     });
 
-    testSingleCase(chrono, "within a month", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen een maand", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("within a month");
+        expect(result.text).toBe("Binnen een maand");
 
         expect(result.start).toBeDate(new Date(2012, 8, 10, 12, 14));
     });
 
+    // TODO fix
     testSingleCase(chrono, "within a few months", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("within a few months");
@@ -108,108 +110,38 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 10, 10, 12, 14));
     });
 
-    testSingleCase(chrono, "within one year", new Date(2012, 7, 10, 12, 14), (result) => {
+
+    testSingleCase(chrono.nl, "Binnen een jaar", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("within one year");
+        expect(result.text).toBe("Binnen een jaar");
 
         expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
     });
 
-    testSingleCase(chrono, "within one Year", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen 5 minuten A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("within one Year");
-
-        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
-    });
-
-    testSingleCase(chrono, "within One year", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("within One year");
-
-        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
-    });
-
-    testSingleCase(chrono, "In 5 Minutes A car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("In 5 Minutes");
+        expect(result.text).toBe("Binnen 5 minuten");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "In 5 mins a car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen 5 min a car need to move", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
-        expect(result.text).toBe("In 5 mins");
+        expect(result.text).toBe("Binnen 5 min");
 
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
-    testSingleCase(chrono, "in a week", new Date(2016, 10 - 1, 1), (result, text) => {
+    testSingleCase(chrono.nl, "binnen een week", new Date(2016, 10 - 1, 1), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
         expect(result.start.get("day")).toBe(8);
     });
-
-    testSingleCase(chrono, "In around 5 hours", new Date(2016, 10 - 1, 1, 13), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("year")).toBe(2016);
-        expect(result.start.get("month")).toBe(10);
-        expect(result.start.get("day")).toBe(1);
-        expect(result.start.get("hour")).toBe(18);
-    });
-
-    testSingleCase(chrono, "In about ~5 hours", new Date(2016, 10 - 1, 1, 13), (result, text) => {
-        expect(result.start.get("year")).toBe(2016);
-        expect(result.start.get("month")).toBe(10);
-        expect(result.start.get("day")).toBe(1);
-        expect(result.start.get("hour")).toBe(18);
-    });
-});
-
-test("Test - The within expression with certain keywords", () => {
-    testSingleCase(chrono, "In  about 5 hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
-        expect(result.text).toBe(text);
-
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(10);
-        expect(result.start.get("hour")).toBe(17);
-        expect(result.start.get("minute")).toBe(49);
-    });
-
-    testSingleCase(chrono, "within around 3 hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
-        expect(result.text).toBe(text);
-
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(10);
-        expect(result.start.get("hour")).toBe(15);
-        expect(result.start.get("minute")).toBe(49);
-    });
-
-    testSingleCase(chrono, "In several hours", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
-        expect(result.text).toBe(text);
-
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(10);
-        expect(result.start.get("hour")).toBe(19);
-        expect(result.start.get("minute")).toBe(49);
-    });
-
-    testSingleCase(chrono, "In a couple of days", new Date(2012, 8 - 1, 10, 12, 49), (result, text) => {
-        expect(result.text).toBe(text);
-
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(12);
-        expect(result.start.get("hour")).toBe(12);
-        expect(result.start.get("minute")).toBe(49);
-    });
 });
 
 test("Test - Single Expression (Implied)", () => {
-    testSingleCase(chrono, "within 30 days", new Date(2012, 7, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen de 30 dagen", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(!result.start.isCertain("year")).not.toBeNull();
         expect(!result.start.isCertain("month")).not.toBeNull();
         expect(!result.start.isCertain("day")).not.toBeNull();
@@ -220,7 +152,7 @@ test("Test - Single Expression (Implied)", () => {
 });
 
 test("Test - Implied time values", () => {
-    testSingleCase(chrono, "in 24 hours", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "Binnen 24 uur", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
         expect(result.start.get("hour")).toBe(12);
         expect(result.start.get("minute")).toBe(14);
         expect(result.start.get("day")).toBe(11);
@@ -228,7 +160,7 @@ test("Test - Implied time values", () => {
         expect(result.start.get("year")).toBe(2020);
     });
 
-    testSingleCase(chrono, "in one day", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
+    testSingleCase(chrono.nl, "binnen een dag", new Date(2020, 7 - 1, 10, 12, 14), (result) => {
         expect(result.start.get("hour")).toBe(12);
         expect(result.start.get("minute")).toBe(14);
         expect(result.start.get("day")).toBe(11);
@@ -238,7 +170,7 @@ test("Test - Implied time values", () => {
 });
 
 test("Test - Time units' certainty", () => {
-    testSingleCase(chrono, "in 2 minute", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+    testSingleCase(chrono.nl, "binnen 2 minuten", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
@@ -253,7 +185,7 @@ test("Test - Time units' certainty", () => {
         expect(result.start.isCertain("minute")).toBeTruthy();
     });
 
-    testSingleCase(chrono, "in 2hour", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+    testSingleCase(chrono.nl, "binnen 2 uur", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
@@ -268,21 +200,7 @@ test("Test - Time units' certainty", () => {
         expect(result.start.isCertain("minute")).toBeTruthy();
     });
 
-    testSingleCase(chrono, "in a few year", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
-        expect(result.text).toBe(text);
-        expect(result.start.get("year")).toBe(2019);
-        expect(result.start.get("month")).toBe(10);
-        expect(result.start.get("day")).toBe(1);
-        expect(result.start.get("hour")).toBe(14);
-        expect(result.start.get("minute")).toBe(52);
-
-        expect(result.start.isCertain("month")).toBeFalsy();
-        expect(result.start.isCertain("day")).toBeFalsy();
-        expect(result.start.isCertain("hour")).toBeFalsy();
-        expect(result.start.isCertain("minute")).toBeFalsy();
-    });
-
-    testSingleCase(chrono, "within 12 month", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+    testSingleCase(chrono.nl, "binnen de 12 maand", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2017);
         expect(result.start.get("month")).toBe(10);
@@ -297,7 +215,7 @@ test("Test - Time units' certainty", () => {
         expect(result.start.isCertain("minute")).toBeFalsy();
     });
 
-    testSingleCase(chrono, "within 3 days", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
+    testSingleCase(chrono.nl, "binnen de 3 dagen", new Date(2016, 10 - 1, 1, 14, 52), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);

--- a/test/nl/nl_weekday.test.ts
+++ b/test/nl/nl_weekday.test.ts
@@ -64,8 +64,8 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 7, 12, 12));
     });
 
-    testSingleCase(chrono.nl, "The Deadline is vorige vrijdag...", new Date(2012, 7, 9), (result) => {
-        expect(result.index).toBe(16);
+    testSingleCase(chrono.nl, "De deadline is vorige vrijdag...", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(15);
         expect(result.text).toBe("vorige vrijdag");
 
         expect(result.start).not.toBeNull();
@@ -77,42 +77,44 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 7, 3, 12));
     });
 
-    testSingleCase(chrono.nl, "Let's have a meeting on vrijdag volgende week", new Date(2015, 3, 18), (result) => {
-        expect(result.index).toBe(21);
-        expect(result.text).toBe("on vrijdag volgende week");
-
-        expect(result.start).not.toBeNull();
-        expect(result.start.get("year")).toBe(2015);
-        expect(result.start.get("month")).toBe(4);
-        expect(result.start.get("day")).toBe(24);
-        expect(result.start.get("weekday")).toBe(5);
-
-        expect(result.start).toBeDate(new Date(2015, 3, 24, 12));
-    });
-
+    // TODO: should be "volgende week vrijdag"
     testSingleCase(
         chrono.nl,
-        "I plan on taking the day off on dinsdag, volgende week",
+        "Laten we een meeting hebben op vrijdag volgende week",
         new Date(2015, 3, 18),
         (result) => {
-            expect(result.index).toBe(29);
-            expect(result.text).toBe("on dinsdag, volgende week");
+            expect(result.index).toBe(31);
+            expect(result.text).toBe("vrijdag volgende week");
 
             expect(result.start).not.toBeNull();
             expect(result.start.get("year")).toBe(2015);
             expect(result.start.get("month")).toBe(4);
-            expect(result.start.get("day")).toBe(21);
-            expect(result.start.get("weekday")).toBe(2);
+            expect(result.start.get("day")).toBe(24);
+            expect(result.start.get("weekday")).toBe(5);
 
-            expect(result.start).toBeDate(new Date(2015, 3, 21, 12));
+            expect(result.start).toBeDate(new Date(2015, 3, 24, 12));
         }
     );
+
+    // TODO: should be "volgende week dinsdag"
+    testSingleCase(chrono.nl, "Ik plan een vrije dag op dinsdag, volgende week", new Date(2015, 3, 18), (result) => {
+        expect(result.index).toBe(25);
+        expect(result.text).toBe("dinsdag, volgende week");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2015);
+        expect(result.start.get("month")).toBe(4);
+        expect(result.start.get("day")).toBe(21);
+        expect(result.start.get("weekday")).toBe(2);
+
+        expect(result.start).toBeDate(new Date(2015, 3, 21, 12));
+    });
 });
 
 test("Test - Weekday With Casual Time", function () {
-    testSingleCase(chrono.nl, "Lets meet on dinsdag ochtend", new Date(2015, 3, 18), (result) => {
-        expect(result.index).toBe(10);
-        expect(result.text).toBe("on dinsdag ochtend");
+    testSingleCase(chrono.nl, "Laten we op dinsdag ochtend afspreken", new Date(2015, 3, 18), (result) => {
+        expect(result.index).toBe(12);
+        expect(result.text).toBe("dinsdag ochtend");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2015);

--- a/test/nl/nl_weekday.test.ts
+++ b/test/nl/nl_weekday.test.ts
@@ -77,14 +77,26 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 7, 3, 12));
     });
 
-    // TODO: should be "volgende week vrijdag"
+    testSingleCase(chrono.nl, "De deadline is vorige vrijdag...", new Date(2012, 7, 12), (result) => {
+        expect(result.index).toBe(15);
+        expect(result.text).toBe("vorige vrijdag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("weekday")).toBe(5);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12));
+    });
+
     testSingleCase(
         chrono.nl,
-        "Laten we een meeting hebben op vrijdag volgende week",
-        new Date(2015, 3, 18),
+        "Laten we een meeting hebben op volgende week vrijdag",
+        new Date(2015, 3, 16),
         (result) => {
-            expect(result.index).toBe(31);
-            expect(result.text).toBe("vrijdag volgende week");
+            expect(result.index).toBe(28);
+            expect(result.text).toBe("op volgende week vrijdag");
 
             expect(result.start).not.toBeNull();
             expect(result.start.get("year")).toBe(2015);
@@ -96,10 +108,9 @@ test("Test - Single Expression", function () {
         }
     );
 
-    // TODO: should be "volgende week dinsdag"
-    testSingleCase(chrono.nl, "Ik plan een vrije dag op dinsdag, volgende week", new Date(2015, 3, 18), (result) => {
-        expect(result.index).toBe(25);
-        expect(result.text).toBe("dinsdag, volgende week");
+    testSingleCase(chrono.nl, "Ik plan een vrije dag op volgende week dinsdag", new Date(2015, 3, 18), (result) => {
+        expect(result.index).toBe(22);
+        expect(result.text).toBe("op volgende week dinsdag");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2015);
@@ -113,8 +124,8 @@ test("Test - Single Expression", function () {
 
 test("Test - Weekday With Casual Time", function () {
     testSingleCase(chrono.nl, "Laten we op dinsdag ochtend afspreken", new Date(2015, 3, 18), (result) => {
-        expect(result.index).toBe(12);
-        expect(result.text).toBe("dinsdag ochtend");
+        expect(result.index).toBe(9);
+        expect(result.text).toBe("op dinsdag ochtend");
 
         expect(result.start).not.toBeNull();
         expect(result.start.get("year")).toBe(2015);

--- a/test/nl/nl_weekday.test.ts
+++ b/test/nl/nl_weekday.test.ts
@@ -1,0 +1,209 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", function () {
+    testSingleCase(chrono.nl, "maandag", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("maandag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("weekday")).toBe(true);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 6, 12));
+    });
+
+    testSingleCase(
+        chrono.nl,
+        "maandag (forward dates only)",
+        new Date(2012, 7, 9),
+        { forwardDate: true },
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("maandag");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(13);
+            expect(result.start.get("weekday")).toBe(1);
+
+            expect(result.start.isCertain("day")).toBe(false);
+            expect(result.start.isCertain("month")).toBe(false);
+            expect(result.start.isCertain("year")).toBe(false);
+            expect(result.start.isCertain("weekday")).toBe(true);
+
+            expect(result.start).toBeDate(new Date(2012, 7, 13, 12));
+        }
+    );
+
+    testSingleCase(chrono.nl, "donderdag", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("donderdag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("weekday")).toBe(4);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 9, 12));
+    });
+
+    testSingleCase(chrono.nl, "zondag", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("zondag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12);
+        expect(result.start.get("weekday")).toBe(0);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 12, 12));
+    });
+
+    testSingleCase(chrono.nl, "The Deadline is vorige vrijdag...", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(16);
+        expect(result.text).toBe("vorige vrijdag");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.start.get("weekday")).toBe(5);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 3, 12));
+    });
+
+    testSingleCase(chrono.nl, "Let's have a meeting on vrijdag volgende week", new Date(2015, 3, 18), (result) => {
+        expect(result.index).toBe(21);
+        expect(result.text).toBe("on vrijdag volgende week");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2015);
+        expect(result.start.get("month")).toBe(4);
+        expect(result.start.get("day")).toBe(24);
+        expect(result.start.get("weekday")).toBe(5);
+
+        expect(result.start).toBeDate(new Date(2015, 3, 24, 12));
+    });
+
+    testSingleCase(
+        chrono.nl,
+        "I plan on taking the day off on dinsdag, volgende week",
+        new Date(2015, 3, 18),
+        (result) => {
+            expect(result.index).toBe(29);
+            expect(result.text).toBe("on dinsdag, volgende week");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2015);
+            expect(result.start.get("month")).toBe(4);
+            expect(result.start.get("day")).toBe(21);
+            expect(result.start.get("weekday")).toBe(2);
+
+            expect(result.start).toBeDate(new Date(2015, 3, 21, 12));
+        }
+    );
+});
+
+test("Test - Weekday With Casual Time", function () {
+    testSingleCase(chrono.nl, "Lets meet on dinsdag ochtend", new Date(2015, 3, 18), (result) => {
+        expect(result.index).toBe(10);
+        expect(result.text).toBe("on dinsdag ochtend");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2015);
+        expect(result.start.get("month")).toBe(4);
+        expect(result.start.get("day")).toBe(21);
+        expect(result.start.get("weekday")).toBe(2);
+        expect(result.start.get("hour")).toBe(6);
+
+        expect(result.start).toBeDate(new Date(2015, 3, 21, 6));
+    });
+});
+
+test("Test - Weekday Overlap", function () {
+    testSingleCase(chrono.nl, "zondag, 7 december 2014", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("zondag, 7 december 2014");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2014);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(7);
+        expect(result.start.get("weekday")).toBe(0);
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("weekday")).toBe(true);
+
+        expect(result.start).toBeDate(new Date(2014, 12 - 1, 7, 12));
+    });
+
+    testSingleCase(chrono.nl, "zondag 7/12/2014", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("zondag 7/12/2014");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2014);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(7);
+        expect(result.start.get("weekday")).toBe(0);
+
+        expect(result.start.isCertain("day")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("weekday")).toBe(true);
+
+        expect(result.start).toBeDate(new Date(2014, 12 - 1, 7, 12));
+    });
+});
+
+test("Test - forward dates only option", function () {
+    testSingleCase(
+        chrono.nl,
+        "deze vrijdag tot deze maandag",
+        new Date(2016, 8 - 1, 4),
+        { forwardDate: true },
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("deze vrijdag tot deze maandag");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2016);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(5);
+            expect(result.start.get("weekday")).toBe(5);
+
+            expect(result.start.isCertain("day")).toBe(false);
+            expect(result.start.isCertain("month")).toBe(false);
+            expect(result.start.isCertain("year")).toBe(false);
+            expect(result.start.isCertain("weekday")).toBe(true);
+
+            expect(result.start).toBeDate(new Date(2016, 8 - 1, 5, 12));
+
+            expect(result.end).not.toBeNull();
+            expect(result.end.get("year")).toBe(2016);
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(8);
+            expect(result.end.get("weekday")).toBe(1);
+
+            expect(result.end.isCertain("day")).toBe(false);
+            expect(result.end.isCertain("month")).toBe(false);
+            expect(result.end.isCertain("year")).toBe(false);
+            expect(result.end.isCertain("weekday")).toBe(true);
+
+            expect(result.end).toBeDate(new Date(2016, 8 - 1, 8, 12));
+        }
+    );
+});

--- a/test/nl/nl_weekday.test.ts
+++ b/test/nl/nl_weekday.test.ts
@@ -20,29 +20,23 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2012, 7, 6, 12));
     });
 
-    testSingleCase(
-        chrono.nl,
-        "maandag (forward dates only)",
-        new Date(2012, 7, 9),
-        { forwardDate: true },
-        (result) => {
-            expect(result.index).toBe(0);
-            expect(result.text).toBe("maandag");
+    testSingleCase(chrono.nl, "maandag (forward dates only)", new Date(2012, 7, 9), { forwardDate: true }, (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("maandag");
 
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(13);
-            expect(result.start.get("weekday")).toBe(1);
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(13);
+        expect(result.start.get("weekday")).toBe(1);
 
-            expect(result.start.isCertain("day")).toBe(false);
-            expect(result.start.isCertain("month")).toBe(false);
-            expect(result.start.isCertain("year")).toBe(false);
-            expect(result.start.isCertain("weekday")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("weekday")).toBe(true);
 
-            expect(result.start).toBeDate(new Date(2012, 7, 13, 12));
-        }
-    );
+        expect(result.start).toBeDate(new Date(2012, 7, 13, 12));
+    });
 
     testSingleCase(chrono.nl, "donderdag", new Date(2012, 7, 9), (result) => {
         expect(result.index).toBe(0);


### PR DESCRIPTION
I wanted to use this library for the `nl` locale, which was added via PR https://github.com/wanasit/chrono/pull/351. I noticed some parsers where not correct and/or incomplete and missing tests.

Changed/fixed
- Fixed NLMonthNameMiddleEndianParser: "januari 13, 2012" -> "13 januari 2012"

Added:
- Tests for all nl parsers and refiners
- Added NLCasualDateTimeParser for combined words like "morgennamiddag", "vanavond" and "gisterenochtend"
- Added NLCasualYearMonthDayParser for YMD pattern support

