### PR TITLE
Fix timezones ParsingOption type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface ParsingOption {
     /**
      * Additional timezone keywords for the parsers to recognize
      */
-    timezones?: { string: number };
+    timezones?: { [tzKeyword: string]: number };
 
     /**
      * Internal debug event handler.


### PR DESCRIPTION
Previously, the timezones parameter was expecting a a single key with the literal value "string" instead of key-value override pairs