### PR TITLE
Require a word boundary after short tokens that can be interpreted as numbers

### DIFF
--- a/src/locales/de/constants.ts
+++ b/src/locales/de/constants.ts
@@ -108,7 +108,7 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
 
 export const NUMBER_PATTERN = `(?:${matchAnyPattern(
     INTEGER_WORD_DICTIONARY
-)}|[0-9]+|[0-9]+\\.[0-9]+|half(?:\\s*an?)?|an?(?:\\s*few)?|few|several|a?\\s*couple\\s*(?:of)?)`;
+)}|[0-9]+|[0-9]+\\.[0-9]+|half(?:\\s*an?)?|an?\\b(?:\\s*few)?|few|several|a?\\s*couple\\s*(?:of)?)`;
 
 export function parseNumberPattern(match: string): number {
     const num = match.toLowerCase();

--- a/src/locales/en/constants.ts
+++ b/src/locales/en/constants.ts
@@ -162,7 +162,7 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
 
 export const NUMBER_PATTERN = `(?:${matchAnyPattern(
     INTEGER_WORD_DICTIONARY
-)}|[0-9]+|[0-9]+\\.[0-9]+|half(?:\\s{0,2}an?)?|an?(?:\\s{0,2}few)?|few|several|a?\\s{0,2}couple\\s{0,2}(?:of)?)`;
+)}|[0-9]+|[0-9]+\\.[0-9]+|half(?:\\s{0,2}an?)?|an?\\b(?:\\s{0,2}few)?|few|several|a?\\s{0,2}couple\\s{0,2}(?:of)?)`;
 
 export function parseNumberPattern(match: string): number {
     const num = match.toLowerCase();

--- a/src/locales/fr/constants.ts
+++ b/src/locales/fr/constants.ts
@@ -105,7 +105,7 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
 
 export const NUMBER_PATTERN = `(?:${matchAnyPattern(
     INTEGER_WORD_DICTIONARY
-)}|[0-9]+|[0-9]+\\.[0-9]+|une?|quelques?|demi-?)`;
+)}|[0-9]+|[0-9]+\\.[0-9]+|une?\\b|quelques?|demi-?)`;
 
 export function parseNumberPattern(match: string): number {
     const num = match.toLowerCase();

--- a/test/en/negative_cases.test.ts
+++ b/test/en/negative_cases.test.ts
@@ -21,6 +21,8 @@ test("Test - Skip random non-date patterns", function () {
     testUnexpectedResult(chrono, "Total: $1,194.09 [image: View Reservation");
 
     testUnexpectedResult(chrono, "at 6.5 kilograms");
+
+    testUnexpectedResult(chrono, "ah that is unusual", new Date(), { forwardDate: true });
 });
 
 test("Test - URLs % encoded", function () {

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -61,10 +61,25 @@ export function testWithExpectedDate(chrono: ChronoLike, text: string, expectedD
     });
 }
 
-export function testUnexpectedResult(chrono: ChronoLike, text: string, refDate?: Date) {
+export function testUnexpectedResult(chrono: ChronoLike, text: string, refDate?: Date);
+export function testUnexpectedResult(
+    chrono: ChronoLike,
+    text: string,
+    refDate?: Date,
+    optionOrCheckResult?: ParsingOption | CheckResult
+);
+export function testUnexpectedResult(
+    chrono: ChronoLike,
+    text: string,
+    refDate?: Date,
+    optionOrCheckResult?: ParsingOption | CheckResult
+) {
     const debugHandler = new BufferedDebugHandler();
+    optionOrCheckResult = (optionOrCheckResult as ParsingOption) || {};
+    optionOrCheckResult.debug = debugHandler;
+
     try {
-        const results = chrono.parse(text, refDate, { debug: debugHandler });
+        const results = chrono.parse(text, refDate, optionOrCheckResult);
         expect(results).toHaveLength(0);
     } catch (e) {
         debugHandler.executeBufferedBlocks();


### PR DESCRIPTION
Resolves #408.