### PR TITLE
Support empty (null) timezone in parser reference date

### DIFF
--- a/src/locales/en/parsers/ENRelativeDateFormatParser.ts
+++ b/src/locales/en/parsers/ENRelativeDateFormatParser.ts
@@ -26,17 +26,17 @@ export default class ENRelativeDateFormatParser extends AbstractParserWithWordBo
         if (modifier == "next") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
-            return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
         }
 
         if (modifier == "last" || modifier == "past") {
             const timeUnits = {};
             timeUnits[timeunit] = -1;
-            return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.refDate);
+        let date = dayjs(context.reference.instant);
 
         // This week
         if (unitWord.match(/week/i)) {

--- a/src/locales/en/parsers/ENRelativeDateFormatParser.ts
+++ b/src/locales/en/parsers/ENRelativeDateFormatParser.ts
@@ -26,13 +26,13 @@ export default class ENRelativeDateFormatParser extends AbstractParserWithWordBo
         if (modifier == "next") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
-            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+            return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
         }
 
         if (modifier == "last" || modifier == "past") {
             const timeUnits = {};
             timeUnits[timeunit] = -1;
-            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+            return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
         }
 
         const components = context.createParsingComponents();

--- a/src/locales/en/parsers/ENTimeUnitAgoFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitAgoFormatParser.ts
@@ -20,6 +20,6 @@ export default class ENTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitAgoFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitAgoFormatParser.ts
@@ -20,6 +20,6 @@ export default class ENTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, outputTimeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitCasualRelativeFormatParser.ts
@@ -22,6 +22,6 @@ export default class ENTimeUnitCasualRelativeFormatParser extends AbstractParser
                 break;
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitCasualRelativeFormatParser.ts
@@ -22,6 +22,6 @@ export default class ENTimeUnitCasualRelativeFormatParser extends AbstractParser
                 break;
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitLaterFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitLaterFormatParser.ts
@@ -22,6 +22,6 @@ export default class ENTimeUnitLaterFormatParser extends AbstractParserWithWordB
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const fragments = parseTimeUnits(match[GROUP_NUM_TIMEUNITS]);
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, fragments);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, fragments);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitLaterFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitLaterFormatParser.ts
@@ -22,6 +22,6 @@ export default class ENTimeUnitLaterFormatParser extends AbstractParserWithWordB
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const fragments = parseTimeUnits(match[GROUP_NUM_TIMEUNITS]);
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, fragments);
+        return ParsingComponents.createRelativeFromReference(context.reference, fragments);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -21,6 +21,6 @@ export default class ENTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -21,6 +21,6 @@ export default class ENTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
@@ -17,6 +17,6 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, outputTimeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
@@ -17,6 +17,6 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
@@ -38,6 +38,6 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
             timeUnits = reverseTimeUnits(timeUnits);
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
@@ -38,6 +38,6 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
             timeUnits = reverseTimeUnits(timeUnits);
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
@@ -10,6 +10,6 @@ export default class FRTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitWithinFormatParser.ts
@@ -10,6 +10,6 @@ export default class FRTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -27,13 +27,13 @@ export default class NLRelativeDateFormatParser extends AbstractParserWithWordBo
         if (modifier == "volgend" || modifier == "volgende" || modifier == "komende") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
-            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+            return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
         }
 
         if (modifier == "afgelopen" || modifier == "vorige") {
             const timeUnits = {};
             timeUnits[timeunit] = -1;
-            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+            return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
         }
 
         const components = context.createParsingComponents();

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -27,17 +27,17 @@ export default class NLRelativeDateFormatParser extends AbstractParserWithWordBo
         if (modifier == "volgend" || modifier == "volgende" || modifier == "komende") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
-            return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
         }
 
         if (modifier == "afgelopen" || modifier == "vorige") {
             const timeUnits = {};
             timeUnits[timeunit] = -1;
-            return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+            return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.refDate);
+        let date = dayjs(context.reference.instant);
 
         // This week
         if (unitWord.match(/week/i)) {

--- a/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
@@ -21,6 +21,6 @@ export default class NLTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, outputTimeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
@@ -21,6 +21,6 @@ export default class NLTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         const timeUnits = parseTimeUnits(match[1]);
         const outputTimeUnits = reverseTimeUnits(timeUnits);
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, outputTimeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -22,6 +22,6 @@ export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParser
                 break;
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -22,6 +22,6 @@ export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParser
                 break;
         }
 
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitLaterFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitLaterFormatParser.ts
@@ -22,6 +22,6 @@ export default class NLTimeUnitLaterFormatParser extends AbstractParserWithWordB
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const fragments = parseTimeUnits(match[GROUP_NUM_TIMEUNITS]);
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, fragments);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, fragments);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitLaterFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitLaterFormatParser.ts
@@ -22,6 +22,6 @@ export default class NLTimeUnitLaterFormatParser extends AbstractParserWithWordB
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const fragments = parseTimeUnits(match[GROUP_NUM_TIMEUNITS]);
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, fragments);
+        return ParsingComponents.createRelativeFromReference(context.reference, fragments);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
@@ -10,6 +10,6 @@ export default class NLTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.refDate, timeUnits);
+        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
     }
 }

--- a/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitWithinFormatParser.ts
@@ -10,6 +10,6 @@ export default class NLTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
         const timeUnits = parseTimeUnits(match[1]);
-        return ParsingComponents.createRelativeFromRefInstant(context.reference, timeUnits);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
     }
 }

--- a/src/results.ts
+++ b/src/results.ts
@@ -168,23 +168,22 @@ export class ParsingComponents implements ParsedComponents {
     }
 
     static createRelativeFromRefInstant(
-        refInstant: Date,
+        reference: ReferenceWithTimezone,
         fragments: { [c in OpUnitType | QUnitType]?: number }
     ): ParsingComponents {
-        let date = dayjs(refInstant);
+        let date = dayjs(reference.instant);
         for (const key in fragments) {
             date = date.add(fragments[key as OpUnitType], key as OpUnitType);
         }
 
-        const reference = new ReferenceWithTimezone(refInstant);
         const components = new ParsingComponents(reference);
         if (fragments["hour"] || fragments["minute"] || fragments["second"]) {
             assignSimilarTime(components, date);
             assignSimilarDate(components, date);
-            components.assign("timezoneOffset", -refInstant.getTimezoneOffset());
+            components.assign("timezoneOffset", -reference.instant.getTimezoneOffset());
         } else {
             implySimilarTime(components, date);
-            components.imply("timezoneOffset", -refInstant.getTimezoneOffset());
+            components.imply("timezoneOffset", -reference.instant.getTimezoneOffset());
 
             if (fragments["d"]) {
                 components.assign("day", date.date());

--- a/src/results.ts
+++ b/src/results.ts
@@ -167,7 +167,7 @@ export class ParsingComponents implements ParsedComponents {
         return currentTimezoneOffset - targetTimezoneOffset;
     }
 
-    static createRelativeFromRefInstant(
+    static createRelativeFromReference(
         reference: ReferenceWithTimezone,
         fragments: { [c in OpUnitType | QUnitType]?: number }
     ): ParsingComponents {

--- a/src/results.ts
+++ b/src/results.ts
@@ -8,7 +8,7 @@ dayjs.extend(quarterOfYear);
 
 export class ReferenceWithTimezone {
     readonly instant: Date;
-    readonly timezoneOffset: number;
+    readonly timezoneOffset?: number;
 
     constructor(input?: ParsingReference | Date) {
         input = input ?? new Date();
@@ -17,7 +17,7 @@ export class ReferenceWithTimezone {
             this.timezoneOffset = -input.getTimezoneOffset();
         } else {
             this.instant = input.instant ?? new Date();
-            this.timezoneOffset = toTimezoneOffset(input.timezone ?? -this.instant.getTimezoneOffset());
+            this.timezoneOffset = toTimezoneOffset(input.timezone);
         }
     }
 }
@@ -180,10 +180,14 @@ export class ParsingComponents implements ParsedComponents {
         if (fragments["hour"] || fragments["minute"] || fragments["second"]) {
             assignSimilarTime(components, date);
             assignSimilarDate(components, date);
-            components.assign("timezoneOffset", -reference.instant.getTimezoneOffset());
+            if (reference.timezoneOffset !== null) {
+                components.assign("timezoneOffset", -reference.instant.getTimezoneOffset());
+            }
         } else {
             implySimilarTime(components, date);
-            components.imply("timezoneOffset", -reference.instant.getTimezoneOffset());
+            if (reference.timezoneOffset !== null) {
+                components.imply("timezoneOffset", -reference.instant.getTimezoneOffset());
+            }
 
             if (fragments["d"]) {
                 components.assign("day", date.date());

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -193,6 +193,10 @@ export const TIMEZONE_ABBR_MAP = {
 };
 
 export function toTimezoneOffset(timezoneInput: string | number): number {
+    if (timezoneInput === null) {
+        return null;
+    }
+
     if (typeof timezoneInput === "number") {
         return timezoneInput;
     }

--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -192,7 +192,7 @@ export const TIMEZONE_ABBR_MAP = {
     YEKT: 360,
 };
 
-export function toTimezoneOffset(timezoneInput: string | number): number {
+export function toTimezoneOffset(timezoneInput: string | number): number | null {
     if (timezoneInput === null) {
         return null;
     }

--- a/test/en/en_relative.test.ts
+++ b/test/en/en_relative.test.ts
@@ -230,4 +230,14 @@ test("Test - Relative date components' certainty and imply timezone", () => {
         expect(result).toBeDate(new Date("Sun Nov 29 2020 13:34:13 GMT+0900 (Japan Standard Time)"));
         expect(result).toBeDate(new Date("Sun Nov 29 2020 5:34:13 GMT+0100"));
     }
+
+    {
+        const text = "in 20 minutes";
+        const result = chrono.parse(text, { instant: refDate, timezone: null })[0] as ParsingResult;
+
+        expect(result.text).toBe(text);
+
+        expect(result).toBeDate(new Date("Sun Nov 29 2020 04:44:13 GMT+0000"));
+        expect(result.start.isCertain("timezoneOffset")).toBe(false);
+    }
 });


### PR DESCRIPTION
Previously, any `timezone` value passed in the `reference` parsing context would always result in a non-empty `ReferenceWithTimezone.timezoneOffset`.  In particular, passing `null` would result in a timezone offset of `-0`.

Although there is probably a neater and more maintainable implementation possible, the intent here is to allow the caller to provide a `null` value for `timezone` -- the resulting `timezoneOffset` will only be overridden in cases when `chrono` finds a known/implied timezone in the text.

This is useful in situations where source texts do not have easily-determined timezones, and allows the caller to ignore results that 'look like' times according to `chrono` but where a definite (`isCertain`) timezone is not available.

**NB**: The diff here may be easier to view at this URL: https://github.com/jayaddison-collabora/chrono/compare/refactor/migrate-createRelativeFromRefInstant...jayaddison-collabora:issue-407/allow-empty-reference-timezone since it builds upon a refactor branch.

Resolves #407.

Relates to https://github.com/mattermost/mattermost-plugin-walltime/pull/40.