### PR TITLE
Fixup for #411: allow the 'now' casual reference function to support null reference timezones

### DIFF
--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -8,7 +8,9 @@ export function now(reference: ReferenceWithTimezone): ParsingComponents {
     const component = new ParsingComponents(reference, {});
     assignSimilarDate(component, targetDate);
     assignSimilarTime(component, targetDate);
-    component.assign("timezoneOffset", targetDate.utcOffset());
+    if (reference.timezoneOffset !== null) {
+        component.assign("timezoneOffset", targetDate.utcOffset());
+    }
     return component;
 }
 

--- a/test/en/en_casual.test.ts
+++ b/test/en/en_casual.test.ts
@@ -21,6 +21,17 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 8, 9, 10, 11));
     });
 
+    testSingleCase(
+        chrono.casual,
+        "The Deadline is now, without implicit local timezone",
+        { instant: new Date(1637674343000), timezone: null },
+        (result) => {
+            expect(result.text).toBe("now");
+            expect(result.start).toBeDate(new Date(1637674343000));
+            expect(result.start.isCertain("timezoneOffset")).toBe(false);
+        }
+    );
+
     testSingleCase(chrono.casual, "The Deadline is today", new Date(2012, 7, 10, 14, 12), (result) => {
         expect(result.index).toBe(16);
         expect(result.text).toBe("today");


### PR DESCRIPTION
Apologies @wanasit - this bug/gap is something I missed during #411, due to not adding a relevant test case for parsing of text containing the phrase `now`.

The fix is to add the same guard statements around in the `now` function as were [added to the `createRelativeFromReference` function](https://github.com/wanasit/chrono/pull/411/files#diff-1c0edb2e88e4f027868f0b0389e98b0ee10cf56d0949c931f9b5f2c7831bc191L184-R190).

This relates to #407.