### PR TITLE
Update MSK to UTC+3:00

### DIFF
--- a/src/timezone.ts
+++ b/src/timezone.ts
@@ -114,7 +114,7 @@ export const TIMEZONE_ABBR_MAP = {
     MHT: 720,
     MMT: 390,
     MSD: 240,
-    MSK: 240,
+    MSK: 180,
     MST: -420,
     MUT: 240,
     MVT: 300,


### PR DESCRIPTION
Moscow Time is permanently on UTC+3:00, which was changed from UTC+4:00
in 2014: https://www.worldtimezone.com/dst_news/dst_news_russia65.html

In IANA tzdb:

> Zone Europe/Moscow   2:30:17 -  LMT 1880
>        2:30:17 -  MMT 1916 Jul  3 # Moscow Mean Time
>        2:31:19 Russia %s  1919 Jul  1  0:00u
>        3:00 Russia  %s  1921 Oct
>        3:00 Russia  MSK/MSD 1922 Oct
>        2:00 - EET 1930 Jun 21
>        3:00 Russia  MSK/MSD 1991 Mar 31  2:00s
>        2:00 Russia  EE%sT 1992 Jan 19  2:00s
>        3:00 Russia  MSK/MSD 2011 Mar 27  2:00s
>        4:00 - MSK 2014 Oct 26  2:00s
>        3:00 - MSK