### PR TITLE
Address handling of ambiguous timezone references

### DIFF
--- a/test/en/negative_cases.test.ts
+++ b/test/en/negative_cases.test.ts
@@ -67,3 +67,10 @@ test("Test - Date with version number pattern", () => {
         expect(result.text).toBe("2015-09-24");
     });
 });
+
+test("Test - Month with ambiguous trailing token", () => {
+    testUnexpectedResult(
+        chrono,
+        "People visiting Buñol towards the end of August get a good chance to participate in La Tomatina (under normal circumstances)"
+    );
+});


### PR DESCRIPTION
#### Summary
Aims to address incorrect interpretation of ambiguous tokens (for example, the word `get` following a month name) as timezones by the library.

#### Ticket Link
Resolves #424.