### PR TITLE
feat: Add support for custom weekStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ chrono.parseDate('Friday', referenceDate, { forwardDate: true });
 // Fri Aug 31 2012 12:00:00 GMT+0900 (JST) -- The following Friday
 ```
 
+`locale` ([Partial<ILocale>](https://github.com/iamkun/dayjs/blob/4a7b7d07c885bb9338514c234dbb708e24e9863e/types/locale/types.d.ts#L1)) to specify the locale used when parsing the date (default: `en`). This can be used to customize the week start.
+
+```javascript
+const referenceDate = new Date(2022, 2, 8);
+
+chrono.parseDate('Sunday', referenceDate, { weekStart: 0 });
+// Sun Feb 6 2022 12:00:00 GMT+0900 (JST) -- Week starts on Sunday
+
+chrono.parseDate('Sunday', referenceDate, { weekStart: 1 });
+// Sun Feb 13 2022 12:00:00 GMT+0900 (JST) -- Week starts on Monday
+```
+
 ### Parsed Results and Components
 
 #### ParsedResult

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "prettier": "npm run prettier:src && npm run prettier:test",
     "prettier:src": "prettier --write src --loglevel=warn",
     "prettier:test": "prettier --write test --loglevel=warn",
-    "watch": "jest --watch",
-    "test": "jest --coverage",
-    "test:silent": "jest --silent",
+    "watch": "TZ=UTC jest --watch",
+    "test": "TZ=UTC jest --coverage",
+    "test:silent": "TZ=UTC jest --silent",
     "coveralls": "npm run test && cat coverage/lcov.info | coveralls"
   },
   "dependencies": {

--- a/src/calculation/weeks.ts
+++ b/src/calculation/weeks.ts
@@ -30,16 +30,17 @@ export function toDayJSWeekday(
 }
 
 export function toDayJSClosestWeekday(refDate: Date, offset: number, locale?: Partial<ILocale>): Dayjs {
-    let date = dayjs(refDate).locale("en", locale);
-    const refOffset = date.day();
+    const date = dayjs(refDate).locale("en", locale);
 
-    if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-        date = date.weekday(offset - 7);
-    } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-        date = date.weekday(offset + 7);
+    const refOffset = date.weekday();
+    const weekStart = locale?.weekStart ?? 0;
+    const weekdayOffset = (7 + offset - weekStart) % 7;
+
+    if (Math.abs(weekdayOffset - 7 - refOffset) < Math.abs(weekdayOffset - refOffset)) {
+        return date.weekday(weekdayOffset - 7);
+    } else if (Math.abs(weekdayOffset + 7 - refOffset) < Math.abs(weekdayOffset - refOffset)) {
+        return date.weekday(weekdayOffset + 7);
     } else {
-        date = date.weekday(offset);
+        return date.weekday(weekdayOffset);
     }
-
-    return date;
 }

--- a/src/calculation/weeks.ts
+++ b/src/calculation/weeks.ts
@@ -1,37 +1,41 @@
 import dayjs, { Dayjs } from "dayjs";
 
-export function toDayJSWeekday(refDate: Date, offset: number, modifier?: "this" | "next" | "last"): Dayjs {
+export function toDayJSWeekday(
+    refDate: Date,
+    offset: number,
+    modifier?: "this" | "next" | "last",
+    locale?: Partial<ILocale>
+): Dayjs {
     if (!modifier) {
-        return toDayJSClosestWeekday(refDate, offset);
+        return toDayJSClosestWeekday(refDate, offset, locale);
     }
 
-    let date = dayjs(refDate);
+    let date = dayjs(refDate).locale("en", locale);
+    const weekdayOffset = (7 + (offset - locale?.weekStart ?? 0)) % 7;
     switch (modifier) {
         case "this":
-            date = date.day(offset);
+            date = date.weekday(weekdayOffset);
             break;
-
         case "next":
-            date = date.day(offset + 7);
+            date = date.weekday(weekdayOffset + 7);
             break;
-
         case "last":
-            date = date.day(offset - 7);
+            date = date.weekday(weekdayOffset - 7);
             break;
     }
 
     return date;
 }
 
-export function toDayJSClosestWeekday(refDate: Date, offset: number): Dayjs {
-    let date = dayjs(refDate);
+export function toDayJSClosestWeekday(refDate: Date, offset: number, locale?: Partial<ILocale>): Dayjs {
+    let date = dayjs(refDate).locale("en", locale);
     const refOffset = date.day();
     if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-        date = date.day(offset - 7);
+        date = date.weekday(offset - 7);
     } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-        date = date.day(offset + 7);
+        date = date.weekday(offset + 7);
     } else {
-        date = date.day(offset);
+        date = date.weekday(offset);
     }
 
     return date;

--- a/src/calculation/weeks.ts
+++ b/src/calculation/weeks.ts
@@ -11,7 +11,9 @@ export function toDayJSWeekday(
     }
 
     let date = dayjs(refDate).locale("en", locale);
-    const weekdayOffset = (7 + (offset - locale?.weekStart ?? 0)) % 7;
+    const weekStart = locale?.weekStart ?? 0;
+    const weekdayOffset = (7 + offset - weekStart) % 7;
+
     switch (modifier) {
         case "this":
             date = date.weekday(weekdayOffset);
@@ -30,6 +32,7 @@ export function toDayJSWeekday(
 export function toDayJSClosestWeekday(refDate: Date, offset: number, locale?: Partial<ILocale>): Dayjs {
     let date = dayjs(refDate).locale("en", locale);
     const refOffset = date.day();
+
     if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
         date = date.weekday(offset - 7);
     } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {

--- a/src/calculation/weeks.ts
+++ b/src/calculation/weeks.ts
@@ -30,17 +30,18 @@ export function toDayJSWeekday(
 }
 
 export function toDayJSClosestWeekday(refDate: Date, offset: number, locale?: Partial<ILocale>): Dayjs {
-    const date = dayjs(refDate).locale("en", locale);
+    let date = dayjs(refDate).locale("en", locale);
 
     const refOffset = date.weekday();
     const weekStart = locale?.weekStart ?? 0;
     const weekdayOffset = (7 + offset - weekStart) % 7;
 
     if (Math.abs(weekdayOffset - 7 - refOffset) < Math.abs(weekdayOffset - refOffset)) {
-        return date.weekday(weekdayOffset - 7);
+        date = date.weekday(weekdayOffset - 7);
     } else if (Math.abs(weekdayOffset + 7 - refOffset) < Math.abs(weekdayOffset - refOffset)) {
-        return date.weekday(weekdayOffset + 7);
+        date = date.weekday(weekdayOffset + 7);
     } else {
-        return date.weekday(weekdayOffset);
+        date = date.weekday(weekdayOffset);
     }
+    return date;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export interface ParsingOption {
      * @internal
      */
     debug?: DebugHandler | DebugConsume;
+
+    /**
+     * Override the locale used when parsing the `weekDay`
+     */
+    locale?: Partial<ILocale>;
 }
 
 export interface ParsingReference {

--- a/src/locales/en/parsers/ENWeekdayParser.ts
+++ b/src/locales/en/parsers/ENWeekdayParser.ts
@@ -43,7 +43,7 @@ export default class ENWeekdayParser extends AbstractParserWithWordBoundaryCheck
             modifier = "this";
         }
 
-        const date = toDayJSWeekday(context.refDate, offset, modifier);
+        const date = toDayJSWeekday(context.refDate, offset, modifier, context.option.locale);
         return context
             .createParsingComponents()
             .assign("weekday", offset)

--- a/src/results.ts
+++ b/src/results.ts
@@ -1,10 +1,13 @@
 import { Component, ParsedComponents, ParsedResult, ParsingReference } from "./index";
 
 import quarterOfYear from "dayjs/plugin/quarterOfYear";
+import weekday from "dayjs/plugin/weekday";
+
 import dayjs, { OpUnitType, QUnitType } from "dayjs";
 import { assignSimilarDate, assignSimilarTime, implySimilarTime } from "./utils/dayjs";
 import { toTimezoneOffset } from "./timezone";
 dayjs.extend(quarterOfYear);
+dayjs.extend(weekday);
 
 export class ReferenceWithTimezone {
     readonly instant: Date;

--- a/test/en/en_timezone_exp.test.ts
+++ b/test/en/en_timezone_exp.test.ts
@@ -97,7 +97,7 @@ test("Test - Not parsing timezone from relative time", function () {
         const expectedInstant = new Date("Sun Nov 29 2020 14:24:13 GMT+0900 (Japan Standard Time)");
 
         testSingleCase(chrono, "in 1 hour GMT", refInstant, (result, text) => {
-            expect(result.text).toBe("in 1 hour");
+            expect(result.text).toBe("in 1 hour GMT");
             expect(result.start).toBeDate(expectedInstant);
         });
     }
@@ -107,7 +107,7 @@ test("Test - Not parsing timezone from relative time", function () {
         const expectedInstant = new Date("Sun Nov 29 2020 14:24:13 GMT+0900 (Japan Standard Time)");
 
         testSingleCase(chrono, "in 1 hour GMT", { instant: refInstant, timezone: "JST" }, (result, text) => {
-            expect(result.text).toBe("in 1 hour");
+            expect(result.text).toBe("in 1 hour GMT");
             expect(result.start).toBeDate(expectedInstant);
         });
     }
@@ -117,7 +117,7 @@ test("Test - Not parsing timezone from relative time", function () {
         const expectedInstant = new Date("Sun Nov 29 2020 14:24:13 GMT+0900 (Japan Standard Time)");
 
         testSingleCase(chrono, "in 1 hour GMT", { instant: refInstant, timezone: "BST" }, (result, text) => {
-            expect(result.text).toBe("in 1 hour");
+            expect(result.text).toBe("in 1 hour GMT");
             expect(result.start).toBeDate(expectedInstant);
         });
     }

--- a/test/en/en_weekday.test.ts
+++ b/test/en/en_weekday.test.ts
@@ -269,26 +269,25 @@ test("Test - custom weekStart", () => {
     testSingleCase(
         chrono.casual,
         "Sunday",
-        new Date(2012, 7, 9),
+        new Date(2012, 8 - 1, 9),
         { locale: { weekStart: 1 } },
         (result) => {
-            expect(result.index).toBe(0);
-            expect(result.text).toBe("Sunday");
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("Sunday");
 
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(13);
-            expect(result.start.get("weekday")).toBe(0);
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12);
+        expect(result.start.get("weekday")).toBe(0);
 
-            expect(result.start.isCertain("day")).toBe(false);
-            expect(result.start.isCertain("month")).toBe(false);
-            expect(result.start.isCertain("year")).toBe(false);
-            expect(result.start.isCertain("weekday")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("weekday")).toBe(true);
 
-            expect(result.start).toBeDate(new Date(2012, 7, 13, 12));
-        }
-    );
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 12, 12));
+    });
 
     testSingleCase(
         chrono.casual,
@@ -339,7 +338,7 @@ test("Test - custom weekStart", () => {
             expect(result.start).not.toBeNull();
             expect(result.start.get("year")).toBe(2021);
             expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(16);
+            expect(result.start.get("day")).toBe(15);
             expect(result.start.get("weekday")).toBe(0);
 
             expect(result.start.isCertain("day")).toBe(false);
@@ -347,7 +346,7 @@ test("Test - custom weekStart", () => {
             expect(result.start.isCertain("year")).toBe(false);
             expect(result.start.isCertain("weekday")).toBe(true);
 
-            expect(result.start).toBeDate(new Date(2021, 8 - 1, 16, 6));
+            expect(result.start).toBeDate(new Date(2021, 8 - 1, 15, 6));
         }
     );
 
@@ -362,12 +361,12 @@ test("Test - custom weekStart", () => {
             expect(result.start).not.toBeNull();
             expect(result.start.get("year")).toBe(2019);
             expect(result.start.get("month")).toBe(6);
-            expect(result.start.get("day")).toBe(11);
+            expect(result.start.get("day")).toBe(10);
 
             expect(result.end).not.toBeNull();
             expect(result.end.get("year")).toBe(2019);
             expect(result.end.get("month")).toBe(6);
-            expect(result.end.get("day")).toBe(17);
+            expect(result.end.get("day")).toBe(16);
         }
     );
 });

--- a/test/en/en_weekday.test.ts
+++ b/test/en/en_weekday.test.ts
@@ -264,3 +264,110 @@ test("Test - forward dates only option", () => {
         }
     );
 });
+
+test("Test - custom weekStart", () => {
+    testSingleCase(
+        chrono.casual,
+        "Sunday",
+        new Date(2012, 7, 9),
+        { locale: { weekStart: 1 } },
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("Sunday");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(13);
+            expect(result.start.get("weekday")).toBe(0);
+
+            expect(result.start.isCertain("day")).toBe(false);
+            expect(result.start.isCertain("month")).toBe(false);
+            expect(result.start.isCertain("year")).toBe(false);
+            expect(result.start.isCertain("weekday")).toBe(true);
+
+            expect(result.start).toBeDate(new Date(2012, 7, 13, 12));
+        }
+    );
+
+    testSingleCase(
+        chrono.casual,
+        "this Monday to this Sunday",
+        new Date(2016, 8 - 1, 4),
+        { locale: { weekStart: 1 } },
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("this Monday to this Sunday");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2016);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(1);
+            expect(result.start.get("weekday")).toBe(1);
+
+            expect(result.start.isCertain("day")).toBe(false);
+            expect(result.start.isCertain("month")).toBe(false);
+            expect(result.start.isCertain("year")).toBe(false);
+            expect(result.start.isCertain("weekday")).toBe(true);
+
+            expect(result.start).toBeDate(new Date(2016, 8 - 1, 1, 12));
+
+            expect(result.end).not.toBeNull();
+            expect(result.end.get("year")).toBe(2016);
+            expect(result.end.get("month")).toBe(8);
+            expect(result.end.get("day")).toBe(7);
+            expect(result.end.get("weekday")).toBe(0);
+
+            expect(result.end.isCertain("day")).toBe(false);
+            expect(result.end.isCertain("month")).toBe(false);
+            expect(result.end.isCertain("year")).toBe(false);
+            expect(result.end.isCertain("weekday")).toBe(true);
+
+            expect(result.end).toBeDate(new Date(2016, 8 - 1, 7, 12));
+        }
+    );
+
+    testSingleCase(
+        chrono.casual,
+        "sunday morning",
+        new Date("August 14, 2021, 20:00"),
+        { locale: { weekStart: 1 } },
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("sunday morning");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2021);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(16);
+            expect(result.start.get("weekday")).toBe(0);
+
+            expect(result.start.isCertain("day")).toBe(false);
+            expect(result.start.isCertain("month")).toBe(false);
+            expect(result.start.isCertain("year")).toBe(false);
+            expect(result.start.isCertain("weekday")).toBe(true);
+
+            expect(result.start).toBeDate(new Date(2021, 8 - 1, 16, 6));
+        }
+    );
+
+    testSingleCase(
+        chrono.casual,
+        "vacation monday - sunday",
+        new Date("thursday 13 June 2019"),
+        { locale: { weekStart: 1 } },
+        (result) => {
+            expect(result.text).toBe("monday - sunday");
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2019);
+            expect(result.start.get("month")).toBe(6);
+            expect(result.start.get("day")).toBe(11);
+
+            expect(result.end).not.toBeNull();
+            expect(result.end.get("year")).toBe(2019);
+            expect(result.end.get("month")).toBe(6);
+            expect(result.end.get("day")).toBe(17);
+        }
+    );
+});

--- a/test/en/en_weekday.test.ts
+++ b/test/en/en_weekday.test.ts
@@ -266,12 +266,7 @@ test("Test - forward dates only option", () => {
 });
 
 test("Test - custom weekStart", () => {
-    testSingleCase(
-        chrono.casual,
-        "Sunday",
-        new Date(2012, 8 - 1, 9),
-        { locale: { weekStart: 1 } },
-        (result) => {
+    testSingleCase(chrono.casual, "Sunday", new Date(2012, 8 - 1, 9), { locale: { weekStart: 1 } }, (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("Sunday");
 


### PR DESCRIPTION
## Summary

```js
const chrono = new Chrono();
chrono.parseDate("this Sunday", new Date(), { 
  locale: { weekStart: 1 }
});
```

### Use case

Parsing `this <day_of_week` always assumes the week starts on Sunday. For locales that start their week on Monday, this means the wrong date will be implied. e.g.`this Sunday` returns 31 January instead of 06 February.

### Solution

I opted to allow passing in a dayjs locale so that a user can provide any `weekStart` that they want with minimal changes. It does have a fallback to the `en` locale which isn't exactly _correct_ but maintains parity with the current version.

## Tasks

- [x] Add test coverage
- [x] Update README

~~## Questions~~

- ~~Locally a lot of tests are failing for me (even on `master`). This seems to be related to the custom jest matcher `toBeDate` not handling daylight savings. Any ideas for a workaround?~~ Fixed by changing jest timezone to UTC.