### PR TITLE
[DE] Add optional "h" to time expression

### DIFF
--- a/src/locales/de/parsers/DETimeExpressionParser.ts
+++ b/src/locales/de/parsers/DETimeExpressionParser.ts
@@ -13,7 +13,7 @@ export default class DETimeExpressionParser extends AbstractTimeExpressionParser
     }
 
     primarySuffix(): string {
-        return "(?:\\s*uhr)?(?:\\s*(?:morgens|vormittags|nachmittags|abends|nachts))?(?=\\W|$)";
+        return "(?:\\s*(?:h|uhr))?(?:\\s*(?:morgens|vormittags|nachmittags|abends|nachts))?(?=\\W|$)";
     }
 
     extractPrimaryTimeComponents(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | null {


### PR DESCRIPTION
The time `4pm` is often represented as `16h` in German.