### PR TITLE
Added parsing for quarter

### DIFF
--- a/src/locales/en/constants.ts
+++ b/src/locales/en/constants.ts
@@ -1,4 +1,4 @@
-import { OpUnitType } from "dayjs";
+import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { TimeUnits } from "../../utils/timeunits";
@@ -133,7 +133,7 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "thirty-first": 31,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
     sec: "second",
     second: "second",
     seconds: "second",
@@ -152,6 +152,9 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
     weeks: "week",
     month: "month",
     months: "month",
+    qtr: "quarter",
+    quarter: "quarter",
+    quarters: "quarter",
     y: "year",
     yr: "year",
     year: "year",

--- a/test/en/en_relative.test.ts
+++ b/test/en/en_relative.test.ts
@@ -136,6 +136,45 @@ test("Test - Future relative expressions", () => {
         expect(result.start.isCertain("timezoneOffset")).toBe(false);
     });
 
+    testSingleCase(chrono, "next quarter", new Date(2021, 1 - 1, 22, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2021);
+        expect(result.start.get("month")).toBe(4);
+        expect(result.start.get("day")).toBe(22);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("hour")).toBe(false);
+    });
+
+    testSingleCase(chrono, "next qtr", new Date(2021, 10 - 1, 22, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(22);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("hour")).toBe(false);
+    });
+
+    testSingleCase(chrono, "next two quarter", new Date(2021, 1 - 1, 22, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2021);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(22);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start.isCertain("year")).toBe(false);
+        expect(result.start.isCertain("month")).toBe(false);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("hour")).toBe(false);
+    });
+
     testSingleCase(chrono, "after this year", new Date(2020, 11 - 1, 22, 12, 11, 32, 6), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2021);


### PR DESCRIPTION
This supports text like, "next quarter", "last quarter", "next two quarter", "after this quarter".