### PR TITLE
Parse timezone offsets that are enclosed in parentheses; restrict max tzOffset

### DIFF
--- a/src/common/refiners/ExtractTimezoneOffsetRefiner.ts
+++ b/src/common/refiners/ExtractTimezoneOffsetRefiner.ts
@@ -26,6 +26,10 @@ export default class ExtractTimezoneOffsetRefiner implements Refiner {
             const hourOffset = parseInt(match[TIMEZONE_OFFSET_HOUR_OFFSET_GROUP]);
             const minuteOffset = parseInt(match[TIMEZONE_OFFSET_MINUTE_OFFSET_GROUP] || "0");
             let timezoneOffset = hourOffset * 60 + minuteOffset;
+            // No timezones have offsets greater than 14 hours, so disregard this match
+            if (timezoneOffset > 14 * 60) {
+                return;
+            }
             if (match[TIMEZONE_OFFSET_SIGN_GROUP] === "-") {
                 timezoneOffset = -timezoneOffset;
             }

--- a/src/common/refiners/ExtractTimezoneOffsetRefiner.ts
+++ b/src/common/refiners/ExtractTimezoneOffsetRefiner.ts
@@ -1,7 +1,7 @@
 import { ParsingContext, Refiner } from "../../chrono";
 import { ParsingResult } from "../../results";
 
-const TIMEZONE_OFFSET_PATTERN = new RegExp("^\\s*(?:(?:GMT|UTC)\\s?)?([+-])(\\d{1,2})(?::?(\\d{2}))?", "i");
+const TIMEZONE_OFFSET_PATTERN = new RegExp("^\\s*(?:\\(?(?:GMT|UTC)\\s?)?([+-])(\\d{1,2})(?::?(\\d{2}))?\\)?", "i");
 const TIMEZONE_OFFSET_SIGN_GROUP = 1;
 const TIMEZONE_OFFSET_HOUR_OFFSET_GROUP = 2;
 const TIMEZONE_OFFSET_MINUTE_OFFSET_GROUP = 3;

--- a/test/en/en_timezone_exp.test.ts
+++ b/test/en/en_timezone_exp.test.ts
@@ -27,6 +27,25 @@ test("Test - Parsing date/time with UTC offset", function () {
     });
 });
 
+test("Test - Parsing date/time with numeric offset", () => {
+    testSingleCase(chrono, "wednesday, september 16, 2020 at 23.00+14", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.isCertain("timezoneOffset")).toBe(true);
+        expect(result.start.get("timezoneOffset")).toBe(14 * 60);
+    });
+
+    testSingleCase(chrono, "wednesday, september 16, 2020 at 23.00+1400", (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.isCertain("timezoneOffset")).toBe(true);
+        expect(result.start.get("timezoneOffset")).toBe(14 * 60);
+    });
+
+    testSingleCase(chrono, "wednesday, september 16, 2020 at 23.00+15", (result, text) => {
+        expect(result.text).toBe("wednesday, september 16, 2020 at 23.00");
+        expect(result.start.isCertain("timezoneOffset")).toBe(false);
+    });
+});
+
 test("Test - Parsing date/time with GMT offset", function () {
     testSingleCase(chrono, "wednesday, september 16, 2020 at 11 am GMT -08:45 ", (result, text) => {
         expect(result.text).toBe("wednesday, september 16, 2020 at 11 am GMT -08:45");

--- a/test/en/en_timezone_exp.test.ts
+++ b/test/en/en_timezone_exp.test.ts
@@ -43,6 +43,14 @@ test("Test - Parsing date/time with GMT offset", function () {
         expect(result.start.get("minute")).toBe(0);
         expect(result.start.get("timezoneOffset")).toBe(2 * 60);
     });
+
+    testSingleCase(chrono, "published: 10:30 (gmt-2:30).", (result, text) => {
+        expect(result.text).toBe("10:30 (gmt-2:30)");
+
+        expect(result.start.get("hour")).toBe(10);
+        expect(result.start.get("minute")).toBe(30);
+        expect(result.start.get("timezoneOffset")).toBe(-(2 * 60 + 30));
+    });
 });
 
 test("Test - Parsing date/time with timezone abbreviation", function () {


### PR DESCRIPTION
Simple improvement. In making this change, I made a few trade-offs:

* It allows text with an open parenthesis without a closing parenthesis, e.g. `10.30 (UTC+4`. I don't see a huge benefit to disallowing this, and doing so would make the regex much more complex.
* It requires a GMT/UTC prefix to match offsets wrapped in parentheses, i.e. allow `10.30 (UTC+4)`, disallow `10.30 (+4)`. I did this because I have found chrono to be too eager to match math-like expressions. This may, however, be improved in 4756d0dd5b816d3e5aa3b90024e064750ce82f98, so I'm not sure if I have made the right call. On the other hand, I think the `(+4)` format is very rarely used.