### PR TITLE
fix(README): ParsingReference "instant" instead of "instance"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ chrono.parseDate("Friday at 4pm", {
 ```
 
 #### ParsingReference
-* `instance?: Date` The instant when the input is written or mentioned
+* `instant?: Date` The instant when the input is written or mentioned
 * `timezone?: string | number` The timezone where the input is written or mentioned. 
   Support minute-offset (number) and timezone name (e.g. "GMT", "CDT")
 


### PR DESCRIPTION
As per https://github.com/wanasit/chrono/blob/c4cd375591f1c51c5e4001814203bda5a838bbdd/src/chrono.ts#L151, it should be "instant" ParsingReference instead of "instance"