### PR TITLE
ru: removes unnecessary replace in parseOrdinalNumberPattern

### DIFF
--- a/src/locales/ru/constants.ts
+++ b/src/locales/ru/constants.ts
@@ -288,8 +288,6 @@ export function parseOrdinalNumberPattern(match: string): number {
     if (ORDINAL_WORD_DICTIONARY[num] !== undefined) {
         return ORDINAL_WORD_DICTIONARY[num];
     }
-
-    num = num.replace(/(?:st|nd|rd|th)$/i, "");
     return parseInt(num);
 }
 


### PR DESCRIPTION
Hi, 
I noticed that in ru locale in `parseOrdinalNumberPattern` I used English suffixes. I guess it worked because parseInt just ignores non-digital ending.
Documentation:
> If parseInt encounters a character that is not a numeral in the specified radix, it ignores it and all succeeding characters and returns the integer value parsed up to that point.

I suggest to remove this `replace`.