### PR TITLE
docs: Corrects supported locale options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ chrono.en.parseDate('6/10/2018');
 chrono.ja.parseDate('昭和６４年１月７日'); 
 ```
 
-Current supported locale options are: `en`, `ja`
+Current supported locale options are: `en`, `ja`, `fr`, `nl` and `ru` (`de`, `pt`, and `zh.hant` are partially supported).
 
 ## Customize Chrono
 


### PR DESCRIPTION
Adds a little redundancy to README, since the same list is specified on line 40:

> The current fully supported languages are `en`, `ja`, `fr`, `nl` and `ru` (`de`, `pt`, and `zh.hant` are partially supported). 

But maybe it's more clear to have the full list also in **Locale** section. 
