### PR TITLE
Add 'night' to casual reference

### DIFF
--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -82,6 +82,13 @@ export function evening(reference: ReferenceWithTimezone, implyHour = 20): Parsi
     return component;
 }
 
+export function night(reference: ReferenceWithTimezone, implyHour = 22): ParsingComponents {
+    const component = new ParsingComponents(reference, {});
+    component.imply("meridiem", Meridiem.PM);
+    component.imply("hour", implyHour);
+    return component;
+}
+
 export function yesterdayEvening(reference: ReferenceWithTimezone, implyHour = 20): ParsingComponents {
     let targetDate = dayjs(reference.instant);
     const component = new ParsingComponents(reference, {});


### PR DESCRIPTION
Defaulting to 10pm. Initially I intended to make it simply an alias of `night`, but since `lastNight` defaults to midnight it seems wrong.