### PR TITLE
Expose ParsingResult from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { DebugHandler, DebugConsume } from "./debugging";
 import * as en from "./locales/en";
 import { Chrono, Parser, Refiner } from "./chrono";
+import type { ParsingResult } from "./results";
 
-export { en, Chrono, Parser, Refiner };
+export { en, Chrono, Parser, Refiner, ParsingResult };
 
 export interface ParsingOption {
     /**


### PR DESCRIPTION
This is a very minor change as it's only a type export. One example where I have needed it is when adding a custom refiner:

```javascript
...
const chronoStrict = chrono.strict.clone();
chronoStrict.refiners.push({refine: (_context, results: Array<ParsingResult>) => results.filter(res => !refineExp.test(res.text))});
```
