### PR TITLE
[JA] Add support for Hiragana

### DIFF
--- a/src/locales/ja/parsers/JPCasualDateParser.ts
+++ b/src/locales/ja/parsers/JPCasualDateParser.ts
@@ -3,7 +3,30 @@ import dayjs from "dayjs";
 import { Meridiem } from "../../../index";
 import * as references from "../../../common/casualReferences";
 
-const PATTERN = /今日|当日|昨日|明日|今夜|今夕|今晩|今朝/i;
+const PATTERN = /今日|きょう|当日|とうじつ|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
+
+function normalizeTextToKanji(str: string) {
+    switch (str) {
+        case "きょう":
+            return "今日";
+        case "とうじつ":
+            return "当日";
+        case "きのう":
+            return "昨日";
+        case "あした":
+            return "明日";
+        case "こんや":
+            return "今夜";
+        case "こんゆう":
+            return "今夕";
+        case "こんばん":
+            return "今晩";
+        case "けさ":
+            return "今朝";
+        default:
+            return str;
+    }
+}
 
 export default class JPCasualDateParser implements Parser {
     pattern() {
@@ -11,7 +34,7 @@ export default class JPCasualDateParser implements Parser {
     }
 
     extract(context: ParsingContext, match: RegExpMatchArray) {
-        const text = match[0];
+        const text = normalizeTextToKanji(match[0]);
 
         const date = dayjs(context.refDate);
         const components = context.createParsingComponents();

--- a/src/locales/ja/parsers/JPCasualDateParser.ts
+++ b/src/locales/ja/parsers/JPCasualDateParser.ts
@@ -5,8 +5,8 @@ import * as references from "../../../common/casualReferences";
 
 const PATTERN = /今日|きょう|当日|とうじつ|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
 
-function normalizeTextToKanji(str: string) {
-    switch (str) {
+function normalizeTextToKanji(text: string) {
+    switch (text) {
         case "きょう":
             return "今日";
         case "とうじつ":
@@ -24,7 +24,7 @@ function normalizeTextToKanji(str: string) {
         case "けさ":
             return "今朝";
         default:
-            return str;
+            return text;
     }
 }
 

--- a/test/ja/ja_casual.test.ts
+++ b/test/ja/ja_casual.test.ts
@@ -4,12 +4,7 @@ import { testSingleCase } from "../test_util";
 test("Test - Single Expression", function () {
     function testToday(pattern: string) {
         testSingleCase(chrono.ja, `${pattern}感じたことを忘れずに`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.index).toBe(0);
             expect(result.text).toBe(pattern);
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(10);
             expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
         });
     }
@@ -19,14 +14,7 @@ test("Test - Single Expression", function () {
 
     function testYesterday(pattern: string) {
         testSingleCase(chrono.ja, `${pattern}の全国観測値ランキング`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.index).toBe(0);
             expect(result.text).toBe(pattern);
-
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(9);
-
             expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
         });
     }
@@ -35,14 +23,7 @@ test("Test - Single Expression", function () {
 
     function testTomorrow(pattern: string) {
         testSingleCase(chrono.ja, `${pattern}の天気は晴れです`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.index).toBe(0);
             expect(result.text).toBe(pattern);
-
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(11);
-
             expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
         });
     }
@@ -52,15 +33,7 @@ test("Test - Single Expression", function () {
 
     function testTonight(pattern: string) {
         testSingleCase(chrono.ja, `${pattern}には雨が降るでしょう`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.index).toBe(0);
             expect(result.text).toBe(pattern);
-
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(10);
-            expect(result.start.get("meridiem")).toBe(chrono.Meridiem.PM);
-
             expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
         });
     }
@@ -74,15 +47,7 @@ test("Test - Single Expression", function () {
 
     function testMorning(pattern: string) {
         testSingleCase(chrono.ja, `${pattern}食べたパンは美味しかった`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.index).toBe(0);
             expect(result.text).toBe(pattern);
-
-            expect(result.start).not.toBeNull();
-            expect(result.start.get("year")).toBe(2012);
-            expect(result.start.get("month")).toBe(8);
-            expect(result.start.get("day")).toBe(10);
-            expect(result.start.get("meridiem")).toBe(chrono.Meridiem.AM);
-
             expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
         });
     }

--- a/test/ja/ja_casual.test.ts
+++ b/test/ja/ja_casual.test.ts
@@ -32,4 +32,60 @@ test("Test - Single Expression", function () {
     }
     testYesterday("昨日");
     testYesterday("きのう");
+
+    function testTomorrow(pattern: string) {
+        testSingleCase(chrono.ja, `${pattern}の天気は晴れです`, new Date(2012, 8 - 1, 10, 12), (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe(pattern);
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(11);
+
+            expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
+        });
+    }
+
+    testTomorrow("明日");
+    testTomorrow("あした");
+
+    function testTonight(pattern: string) {
+        testSingleCase(chrono.ja, `${pattern}には雨が降るでしょう`, new Date(2012, 8 - 1, 10, 12), (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe(pattern);
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(10);
+            expect(result.start.get("meridiem")).toBe(chrono.Meridiem.PM);
+
+            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+        });
+    }
+
+    testTonight("今夜");
+    testTonight("こんや");
+    testTonight("今夕");
+    testTonight("こんゆう");
+    testTonight("今晩");
+    testTonight("こんばん");
+
+    function testMorning(pattern: string) {
+        testSingleCase(chrono.ja, `${pattern}食べたパンは美味しかった`, new Date(2012, 8 - 1, 10, 12), (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe(pattern);
+
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(10);
+            expect(result.start.get("meridiem")).toBe(chrono.Meridiem.AM);
+
+            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
+        });
+    }
+    testMorning("今朝");
+    testMorning("けさ");
 });

--- a/test/ja/ja_casual.test.ts
+++ b/test/ja/ja_casual.test.ts
@@ -2,55 +2,64 @@ import * as chrono from "../../src/";
 import { testSingleCase } from "../test_util";
 
 test("Test - Single Expression", function () {
-    function testToday(pattern: string) {
-        testSingleCase(chrono.ja, `${pattern}感じたことを忘れずに`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.text).toBe(pattern);
-            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
-        });
-    }
+    testSingleCase(chrono.ja, "今日感じたことを忘れずに", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("今日");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+    testSingleCase(chrono.ja, "きょう感じたことを忘れずに", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("きょう");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
 
-    testToday("今日");
-    testToday("きょう");
+    testSingleCase(chrono.ja, "昨日の全国観測値ランキング", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("昨日");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
+    });
+    testSingleCase(chrono.ja, "きのうの全国観測値ランキング", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("きのう");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
+    });
 
-    function testYesterday(pattern: string) {
-        testSingleCase(chrono.ja, `${pattern}の全国観測値ランキング`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.text).toBe(pattern);
-            expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
-        });
-    }
-    testYesterday("昨日");
-    testYesterday("きのう");
+    testSingleCase(chrono.ja, "明日の天気は晴れです", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("明日");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
+    });
+    testSingleCase(chrono.ja, "あしたの天気は晴れです", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("あした");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
+    });
 
-    function testTomorrow(pattern: string) {
-        testSingleCase(chrono.ja, `${pattern}の天気は晴れです`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.text).toBe(pattern);
-            expect(result.start).toBeDate(new Date(2012, 8 - 1, 11, 12));
-        });
-    }
+    testSingleCase(chrono.ja, "今夜には雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("今夜");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
+    testSingleCase(chrono.ja, "こんやには雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("こんや");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
+    testSingleCase(chrono.ja, "今夕には雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("今夕");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
+    testSingleCase(chrono.ja, "こんゆうには雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("こんゆう");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
+    testSingleCase(chrono.ja, "今晩には雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("今晩");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
+    testSingleCase(chrono.ja, "こんばんには雨が降るでしょう", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("こんばん");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
+    });
 
-    testTomorrow("明日");
-    testTomorrow("あした");
-
-    function testTonight(pattern: string) {
-        testSingleCase(chrono.ja, `${pattern}には雨が降るでしょう`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.text).toBe(pattern);
-            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 22));
-        });
-    }
-
-    testTonight("今夜");
-    testTonight("こんや");
-    testTonight("今夕");
-    testTonight("こんゆう");
-    testTonight("今晩");
-    testTonight("こんばん");
-
-    function testMorning(pattern: string) {
-        testSingleCase(chrono.ja, `${pattern}食べたパンは美味しかった`, new Date(2012, 8 - 1, 10, 12), (result) => {
-            expect(result.text).toBe(pattern);
-            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
-        });
-    }
-    testMorning("今朝");
-    testMorning("けさ");
+    testSingleCase(chrono.ja, "今朝食べたパンは美味しかった", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("今朝");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
+    });
+    testSingleCase(chrono.ja, "けさ食べたパンは美味しかった", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("けさ");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 6));
+    });
 });

--- a/test/ja/ja_casual.test.ts
+++ b/test/ja/ja_casual.test.ts
@@ -2,27 +2,34 @@ import * as chrono from "../../src/";
 import { testSingleCase } from "../test_util";
 
 test("Test - Single Expression", function () {
-    testSingleCase(chrono.ja, "今日感じたことを忘れずに", new Date(2012, 8 - 1, 10, 12), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("今日");
+    function testToday(pattern: string) {
+        testSingleCase(chrono.ja, `${pattern}感じたことを忘れずに`, new Date(2012, 8 - 1, 10, 12), (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe(pattern);
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(10);
+            expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+        });
+    }
 
-        expect(result.start).not.toBeNull();
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(10);
+    testToday("今日");
+    testToday("きょう");
 
-        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
-    });
+    function testYesterday(pattern: string) {
+        testSingleCase(chrono.ja, `${pattern}の全国観測値ランキング`, new Date(2012, 8 - 1, 10, 12), (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe(pattern);
 
-    testSingleCase(chrono.ja, "昨日の全国観測値ランキング", new Date(2012, 8 - 1, 10, 12), (result) => {
-        expect(result.index).toBe(0);
-        expect(result.text).toBe("昨日");
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("day")).toBe(9);
 
-        expect(result.start).not.toBeNull();
-        expect(result.start.get("year")).toBe(2012);
-        expect(result.start.get("month")).toBe(8);
-        expect(result.start.get("day")).toBe(9);
-
-        expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
-    });
+            expect(result.start).toBeDate(new Date(2012, 8 - 1, 9, 12));
+        });
+    }
+    testYesterday("昨日");
+    testYesterday("きのう");
 });


### PR DESCRIPTION
# TL;DR

This PR adds support for Hiragana(ひらがな) in the Japanese date parser.
I didn't know the best way of treating Hiragana/Kanji, so for now I just did it in the most straight forward, or redundant way.
If you have any thoughts on how to improve this, I'd love to challenge myself!

In addition to adding support for Hiragana, I also added some test cases that seemed to be missing.

Btw, thank you so much for writing this library, and I really appreciate how well this library is maintained.