### PR TITLE
Export `ParsedComponents` again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { DebugHandler, DebugConsume } from "./debugging";
 import * as en from "./locales/en";
 import { Chrono, Parser, Refiner } from "./chrono";
 import { ParsingResult } from "./results";
-import { Component, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday } from "./types";
+import { Component, ParsedComponents, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday } from "./types";
 
 export { en, Chrono, Parser, Refiner, ParsingResult };
 export { Component, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { Chrono, Parser, Refiner } from "./chrono";
 import { ParsingResult } from "./results";
 import { Component, ParsedComponents, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday } from "./types";
 
-export { en, Chrono, Parser, Refiner, ParsingResult };
+export { en, Chrono, Parser, Refiner, ParsedComponents, ParsingResult };
 export { Component, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday };
 
 // Export all locales


### PR DESCRIPTION
We are using the public `ParsedComponents` type, however in https://github.com/wanasit/chrono/commit/feb250d3ca44ff30efb59d62440e576496434d8f when the interfaces where moved `parsing.ts` and later to `types.ts`, `ParsedComponents` was not re-exported again.

There are other interfaces that went private with that change, up to you to decide which ones you want to re-export.