### PR TITLE
Add casualText to expose casual match

### DIFF
--- a/src/chrono.ts
+++ b/src/chrono.ts
@@ -159,12 +159,15 @@ export class ParsingContext implements DebugHandler {
         this.refDate = this.reference.instant;
     }
 
-    createParsingComponents(components?: { [c in Component]?: number } | ParsingComponents): ParsingComponents {
+    createParsingComponents(
+        components?: { [c in Component]?: number } | ParsingComponents,
+        casualText?: string
+    ): ParsingComponents {
         if (components instanceof ParsingComponents) {
             return components;
         }
 
-        return new ParsingComponents(this.reference, components);
+        return new ParsingComponents(this.reference, components, casualText);
     }
 
     createParsingResult(

--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -9,9 +9,9 @@ import {
 } from "../utils/dayjs";
 import { Meridiem } from "../types";
 
-export function now(reference: ReferenceWithTimezone): ParsingComponents {
+export function now(reference: ReferenceWithTimezone, casualText?: string): ParsingComponents {
     const targetDate = dayjs(reference.instant);
-    const component = new ParsingComponents(reference, {});
+    const component = new ParsingComponents(reference, {}, casualText);
     assignSimilarDate(component, targetDate);
     assignSimilarTime(component, targetDate);
     if (reference.timezoneOffset !== null) {
@@ -20,9 +20,9 @@ export function now(reference: ReferenceWithTimezone): ParsingComponents {
     return component;
 }
 
-export function today(reference: ReferenceWithTimezone): ParsingComponents {
+export function today(reference: ReferenceWithTimezone, casualText?: string): ParsingComponents {
     const targetDate = dayjs(reference.instant);
-    const component = new ParsingComponents(reference, {});
+    const component = new ParsingComponents(reference, {}, casualText);
     assignSimilarDate(component, targetDate);
     implySimilarTime(component, targetDate);
     return component;
@@ -31,33 +31,33 @@ export function today(reference: ReferenceWithTimezone): ParsingComponents {
 /**
  * The previous day. Imply the same time.
  */
-export function yesterday(reference: ReferenceWithTimezone): ParsingComponents {
-    return theDayBefore(reference, 1);
+export function yesterday(reference: ReferenceWithTimezone, casualText?: string): ParsingComponents {
+    return theDayBefore(reference, 1, casualText);
 }
 
-export function theDayBefore(reference: ReferenceWithTimezone, numDay: number): ParsingComponents {
-    return theDayAfter(reference, -numDay);
+export function theDayBefore(reference: ReferenceWithTimezone, numDay: number, casualText?: string): ParsingComponents {
+    return theDayAfter(reference, -numDay, casualText);
 }
 
 /**
  * The following day with dayjs.assignTheNextDay()
  */
-export function tomorrow(reference: ReferenceWithTimezone): ParsingComponents {
-    return theDayAfter(reference, 1);
+export function tomorrow(reference: ReferenceWithTimezone, casualText?: string): ParsingComponents {
+    return theDayAfter(reference, 1, casualText);
 }
 
-export function theDayAfter(reference: ReferenceWithTimezone, nDays: number): ParsingComponents {
+export function theDayAfter(reference: ReferenceWithTimezone, nDays: number, casualText?: string): ParsingComponents {
     let targetDate = dayjs(reference.instant);
-    const component = new ParsingComponents(reference, {});
+    const component = new ParsingComponents(reference, {}, casualText);
     targetDate = targetDate.add(nDays, "day");
     assignSimilarDate(component, targetDate);
     implySimilarTime(component, targetDate);
     return component;
 }
 
-export function tonight(reference: ReferenceWithTimezone, implyHour = 22): ParsingComponents {
+export function tonight(reference: ReferenceWithTimezone, implyHour = 22, casualText?: string): ParsingComponents {
     const targetDate = dayjs(reference.instant);
-    const component = new ParsingComponents(reference, {});
+    const component = new ParsingComponents(reference, {}, casualText);
     component.imply("hour", implyHour);
     component.imply("meridiem", Meridiem.PM);
     assignSimilarDate(component, targetDate);

--- a/src/locales/en/parsers/ENCasualDateParser.ts
+++ b/src/locales/en/parsers/ENCasualDateParser.ts
@@ -15,25 +15,24 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
         let targetDate = dayjs(context.refDate);
         const lowerText = match[0].toLowerCase();
-        const component = context.createParsingComponents();
 
         switch (lowerText) {
             case "now":
-                return references.now(context.reference);
+                return references.now(context.reference, "Now");
 
             case "today":
-                return references.today(context.reference);
+                return references.today(context.reference, "Today");
 
             case "yesterday":
-                return references.yesterday(context.reference);
+                return references.yesterday(context.reference, "Yesterday");
 
             case "tomorrow":
             case "tmr":
             case "tmrw":
-                return references.tomorrow(context.reference);
+                return references.tomorrow(context.reference, "Tomorrow");
 
             case "tonight":
-                return references.tonight(context.reference);
+                return references.tonight(context.reference, undefined, "Tonight");
 
             default:
                 if (lowerText.match(/last\s*night/)) {
@@ -41,12 +40,15 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
                         targetDate = targetDate.add(-1, "day");
                     }
 
+                    const component = context.createParsingComponents(undefined, "Last Night");
                     assignSimilarDate(component, targetDate);
                     component.imply("hour", 0);
+
+                    return component;
                 }
                 break;
         }
 
-        return component;
+        return context.createParsingComponents();
     }
 }

--- a/src/results.ts
+++ b/src/results.ts
@@ -50,11 +50,17 @@ export class ParsingComponents implements ParsedComponents {
     private knownValues: { [c in Component]?: number };
     private impliedValues: { [c in Component]?: number };
     private reference: ReferenceWithTimezone;
+    public readonly casualText?: string;
 
-    constructor(reference: ReferenceWithTimezone, knownComponents?: { [c in Component]?: number }) {
+    constructor(
+        reference: ReferenceWithTimezone,
+        knownComponents?: { [c in Component]?: number },
+        casualText?: string
+    ) {
         this.reference = reference;
         this.knownValues = {};
         this.impliedValues = {};
+        this.casualText = casualText;
         if (knownComponents) {
             for (const key in knownComponents) {
                 this.knownValues[key as Component] = knownComponents[key as Component];

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,11 @@ export interface ParsedComponents {
      * @return a javascript date object.
      */
     date(): Date;
+
+    /**
+     * Get the full casual text that matches.
+     */
+    casualText?: string;
 }
 
 export type Component =

--- a/test/en/en_casual.test.ts
+++ b/test/en/en_casual.test.ts
@@ -8,6 +8,7 @@ test("Test - Single Expression", () => {
         expect(result.text).toBe("now");
 
         expect(result.start).not.toBeNull();
+        expect(result.start.casualText).toBe("Now");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(10);
@@ -37,6 +38,7 @@ test("Test - Single Expression", () => {
         expect(result.text).toBe("today");
 
         expect(result.start).not.toBeNull();
+        expect(result.start.casualText).toBe("Today");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(10);
@@ -49,6 +51,7 @@ test("Test - Single Expression", () => {
         expect(result.text).toBe("Tomorrow");
 
         expect(result.start).not.toBeNull();
+        expect(result.start.casualText).toBe("Tomorrow");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(11);
@@ -65,6 +68,7 @@ test("Test - Single Expression", () => {
         expect(result.text).toBe("yesterday");
 
         expect(result.start).not.toBeNull();
+        expect(result.start.casualText).toBe("Yesterday");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(9);
@@ -77,6 +81,7 @@ test("Test - Single Expression", () => {
         expect(result.text).toBe("last night");
 
         expect(result.start).not.toBeNull();
+        expect(result.start.casualText).toBe("Last Night");
         expect(result.start.get("year")).toBe(2012);
         expect(result.start.get("month")).toBe(8);
         expect(result.start.get("day")).toBe(9);


### PR DESCRIPTION
This PR adds casualText to ParsedComponents for user to identify which casual parser matched.

For now I only added it in a few places but I'm happy to add it everywhere if you think it makes sense.

Resolve #524