### PR TITLE
update regex refine french, add 'au'

### DIFF
--- a/src/locales/fr/refiners/FRMergeDateRangeRefiner.ts
+++ b/src/locales/fr/refiners/FRMergeDateRangeRefiner.ts
@@ -10,6 +10,6 @@ import AbstractMergeDateRangeRefiner from "../../../common/refiners/AbstractMerg
  */
 export default class FRMergeDateRangeRefiner extends AbstractMergeDateRangeRefiner {
     patternBetween(): RegExp {
-        return /^\s*(à|a|-)\s*$/i;
+        return /^\s*(à|a|au|-)\s*$/i;
     }
 }

--- a/src/locales/fr/refiners/FRMergeDateTimeRefiner.ts
+++ b/src/locales/fr/refiners/FRMergeDateTimeRefiner.ts
@@ -5,6 +5,6 @@ import AbstractMergeDateTimeRefiner from "../../../common/refiners/AbstractMerge
  */
 export default class FRMergeDateTimeRefiner extends AbstractMergeDateTimeRefiner {
     patternBetween(): RegExp {
-        return new RegExp("^\\s*(T|à|a|vers|de|,|-)?\\s*$");
+        return new RegExp("^\\s*(T|à|a|au|vers|de|,|-)?\\s*$");
     }
 }

--- a/test/fr/fr_casual.test.ts
+++ b/test/fr/fr_casual.test.ts
@@ -132,6 +132,16 @@ test("Test - Single Expression", function () {
         expect(result.text).toBe(text);
         expect(result.start.get("hour")).toBe(0);
     });
+
+    testSingleCase(chrono.fr, "Du 24 août 2023 au 26 août 2023", (result) => {
+        expect(result.text).toBe("24 août 2023 au 26 août 2023");
+        expect(result.start.get("year")).toBe(2023);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(24);
+        expect(result.end.get("year")).toBe(2023);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(26);
+    });
 });
 
 test("Test - Combined Expression", function () {


### PR DESCRIPTION
I add another article _"au"_ for french version, to split start and end dates in the right place.