### PR TITLE
New: Introduce Parsing Tags

### DIFF
--- a/src/calculation/mergingCalculation.ts
+++ b/src/calculation/mergingCalculation.ts
@@ -77,5 +77,7 @@ export function mergeDateTimeComponent(
         }
     }
 
+    dateTimeComponent.addTags(dateComponent.tags());
+    dateTimeComponent.addTags(timeComponent.tags());
     return dateTimeComponent;
 }

--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -17,6 +17,7 @@ export function now(reference: ReferenceWithTimezone): ParsingComponents {
     if (reference.timezoneOffset !== null) {
         component.assign("timezoneOffset", targetDate.utcOffset());
     }
+    component.addTag("casualReference/now");
     return component;
 }
 
@@ -25,6 +26,7 @@ export function today(reference: ReferenceWithTimezone): ParsingComponents {
     const component = new ParsingComponents(reference, {});
     assignSimilarDate(component, targetDate);
     implySimilarTime(component, targetDate);
+    component.addTag("casualReference/today");
     return component;
 }
 

--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -34,7 +34,7 @@ export function today(reference: ReferenceWithTimezone): ParsingComponents {
  * The previous day. Imply the same time.
  */
 export function yesterday(reference: ReferenceWithTimezone): ParsingComponents {
-    return theDayBefore(reference, 1);
+    return theDayBefore(reference, 1).addTag("casualReference/yesterday");
 }
 
 export function theDayBefore(reference: ReferenceWithTimezone, numDay: number): ParsingComponents {
@@ -45,7 +45,7 @@ export function theDayBefore(reference: ReferenceWithTimezone, numDay: number): 
  * The following day with dayjs.assignTheNextDay()
  */
 export function tomorrow(reference: ReferenceWithTimezone): ParsingComponents {
-    return theDayAfter(reference, 1);
+    return theDayAfter(reference, 1).addTag("casualReference/tomorrow");
 }
 
 export function theDayAfter(reference: ReferenceWithTimezone, nDays: number): ParsingComponents {
@@ -60,9 +60,10 @@ export function theDayAfter(reference: ReferenceWithTimezone, nDays: number): Pa
 export function tonight(reference: ReferenceWithTimezone, implyHour = 22): ParsingComponents {
     const targetDate = dayjs(reference.instant);
     const component = new ParsingComponents(reference, {});
+    assignSimilarDate(component, targetDate);
     component.imply("hour", implyHour);
     component.imply("meridiem", Meridiem.PM);
-    assignSimilarDate(component, targetDate);
+    component.addTag("casualReference/tonight");
     return component;
 }
 
@@ -81,6 +82,7 @@ export function evening(reference: ReferenceWithTimezone, implyHour = 20): Parsi
     const component = new ParsingComponents(reference, {});
     component.imply("meridiem", Meridiem.PM);
     component.imply("hour", implyHour);
+    component.addTag("casualReference/evening");
     return component;
 }
 
@@ -91,6 +93,8 @@ export function yesterdayEvening(reference: ReferenceWithTimezone, implyHour = 2
     assignSimilarDate(component, targetDate);
     component.imply("hour", implyHour);
     component.imply("meridiem", Meridiem.PM);
+    component.addTag("casualReference/yesterday");
+    component.addTag("casualReference/evening");
     return component;
 }
 
@@ -106,6 +110,7 @@ export function midnight(reference: ReferenceWithTimezone): ParsingComponents {
     component.imply("minute", 0);
     component.imply("second", 0);
     component.imply("millisecond", 0);
+    component.addTag("casualReference/midnight");
     return component;
 }
 
@@ -116,6 +121,7 @@ export function morning(reference: ReferenceWithTimezone, implyHour = 6): Parsin
     component.imply("minute", 0);
     component.imply("second", 0);
     component.imply("millisecond", 0);
+    component.addTag("casualReference/morning");
     return component;
 }
 
@@ -126,6 +132,7 @@ export function afternoon(reference: ReferenceWithTimezone, implyHour = 15): Par
     component.imply("minute", 0);
     component.imply("second", 0);
     component.imply("millisecond", 0);
+    component.addTag("casualReference/afternoon");
     return component;
 }
 
@@ -136,5 +143,6 @@ export function noon(reference: ReferenceWithTimezone): ParsingComponents {
     component.imply("minute", 0);
     component.imply("second", 0);
     component.imply("millisecond", 0);
+    component.addTag("casualReference/noon");
     return component;
 }

--- a/src/locales/en/parsers/ENCasualDateParser.ts
+++ b/src/locales/en/parsers/ENCasualDateParser.ts
@@ -15,25 +15,35 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
         let targetDate = dayjs(context.refDate);
         const lowerText = match[0].toLowerCase();
-        const component = context.createParsingComponents();
+        let component = context.createParsingComponents();
 
         switch (lowerText) {
             case "now":
-                return references.now(context.reference);
+                component = references.now(context.reference);
+                component.addTag("ENCasualDateParser/extract/now");
+                break;
 
             case "today":
-                return references.today(context.reference);
+                component = references.today(context.reference);
+                component.addTag("ENCasualDateParser/extract/today");
+                break;
 
             case "yesterday":
-                return references.yesterday(context.reference);
+                component = references.yesterday(context.reference);
+                component.addTag("ENCasualDateParser/extract/yesterday");
+                break;
 
             case "tomorrow":
             case "tmr":
             case "tmrw":
-                return references.tomorrow(context.reference);
+                component = references.tomorrow(context.reference);
+                component.addTag("ENCasualDateParser/extract/tomorrow");
+                break;
 
             case "tonight":
-                return references.tonight(context.reference);
+                component = references.tonight(context.reference);
+                component.addTag("ENCasualDateParser/extract/tonight");
+                break;
 
             default:
                 if (lowerText.match(/last\s*night/)) {
@@ -43,6 +53,7 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
 
                     assignSimilarDate(component, targetDate);
                     component.imply("hour", 0);
+                    component.addTag("ENCasualDateParser/extract/last_night");
                 }
                 break;
         }

--- a/src/locales/en/parsers/ENCasualDateParser.ts
+++ b/src/locales/en/parsers/ENCasualDateParser.ts
@@ -20,29 +20,24 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
         switch (lowerText) {
             case "now":
                 component = references.now(context.reference);
-                component.addTag("ENCasualDateParser/extract/now");
                 break;
 
             case "today":
                 component = references.today(context.reference);
-                component.addTag("ENCasualDateParser/extract/today");
                 break;
 
             case "yesterday":
                 component = references.yesterday(context.reference);
-                component.addTag("ENCasualDateParser/extract/yesterday");
                 break;
 
             case "tomorrow":
             case "tmr":
             case "tmrw":
                 component = references.tomorrow(context.reference);
-                component.addTag("ENCasualDateParser/extract/tomorrow");
                 break;
 
             case "tonight":
                 component = references.tonight(context.reference);
-                component.addTag("ENCasualDateParser/extract/tonight");
                 break;
 
             default:
@@ -53,11 +48,10 @@ export default class ENCasualDateParser extends AbstractParserWithWordBoundaryCh
 
                     assignSimilarDate(component, targetDate);
                     component.imply("hour", 0);
-                    component.addTag("ENCasualDateParser/extract/last_night");
                 }
                 break;
         }
-
+        component.addTag("parser/ENCasualDateParser");
         return component;
     }
 }

--- a/src/locales/en/parsers/ENCasualTimeParser.ts
+++ b/src/locales/en/parsers/ENCasualTimeParser.ts
@@ -9,20 +9,29 @@ export default class ENCasualTimeParser extends AbstractParserWithWordBoundaryCh
         return PATTERN;
     }
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
+        let component = null;
         switch (match[1].toLowerCase()) {
             case "afternoon":
-                return casualReferences.afternoon(context.reference);
+                component = casualReferences.afternoon(context.reference);
+                break;
             case "evening":
             case "night":
-                return casualReferences.evening(context.reference);
+                component = casualReferences.evening(context.reference);
+                break;
             case "midnight":
-                return casualReferences.midnight(context.reference);
+                component = casualReferences.midnight(context.reference);
+                break;
             case "morning":
-                return casualReferences.morning(context.reference);
+                component = casualReferences.morning(context.reference);
+                break;
             case "noon":
             case "midday":
-                return casualReferences.noon(context.reference);
+                component = casualReferences.noon(context.reference);
+                break;
         }
-        return null;
+        if (component) {
+            component.addTag("parser/ENCasualTimeParser");
+        }
+        return component;
     }
 }

--- a/src/locales/en/parsers/ENTimeExpressionParser.ts
+++ b/src/locales/en/parsers/ENTimeExpressionParser.ts
@@ -22,34 +22,36 @@ export default class ENTimeExpressionParser extends AbstractTimeExpressionParser
 
     extractPrimaryTimeComponents(context: ParsingContext, match: RegExpMatchArray): null | ParsingComponents {
         const components = super.extractPrimaryTimeComponents(context, match);
-        if (components) {
-            if (match[0].endsWith("night")) {
-                const hour = components.get("hour");
-                if (hour >= 6 && hour < 12) {
-                    components.assign("hour", components.get("hour") + 12);
-                    components.assign("meridiem", Meridiem.PM);
-                } else if (hour < 6) {
-                    components.assign("meridiem", Meridiem.AM);
-                }
-            }
+        if (!components) {
+            return components;
+        }
 
-            if (match[0].endsWith("afternoon")) {
+        if (match[0].endsWith("night")) {
+            const hour = components.get("hour");
+            if (hour >= 6 && hour < 12) {
+                components.assign("hour", components.get("hour") + 12);
                 components.assign("meridiem", Meridiem.PM);
-                const hour = components.get("hour");
-                if (hour >= 0 && hour <= 6) {
-                    components.assign("hour", components.get("hour") + 12);
-                }
-            }
-
-            if (match[0].endsWith("morning")) {
+            } else if (hour < 6) {
                 components.assign("meridiem", Meridiem.AM);
-                const hour = components.get("hour");
-                if (hour < 12) {
-                    components.assign("hour", components.get("hour"));
-                }
             }
         }
 
-        return components;
+        if (match[0].endsWith("afternoon")) {
+            components.assign("meridiem", Meridiem.PM);
+            const hour = components.get("hour");
+            if (hour >= 0 && hour <= 6) {
+                components.assign("hour", components.get("hour") + 12);
+            }
+        }
+
+        if (match[0].endsWith("morning")) {
+            components.assign("meridiem", Meridiem.AM);
+            const hour = components.get("hour");
+            if (hour < 12) {
+                components.assign("hour", components.get("hour"));
+            }
+        }
+
+        return components.addTag("parser/ENTimeExpressionParser");
     }
 }

--- a/src/results.ts
+++ b/src/results.ts
@@ -301,6 +301,7 @@ export class ParsingResult implements ParsedResult {
     }
 
     toString() {
-        return `[ParsingResult {index: ${this.index}, text: '${this.text}', ...}]`;
+        const tags = Array.from(this.tags()).sort();
+        return `[ParsingResult {index: ${this.index}, text: '${this.text}', tags: ${JSON.stringify(tags)} ...}]`;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,9 +77,14 @@ export interface ParsedResult {
     readonly end?: ParsedComponents;
 
     /**
-     * Create a javascript date object (from the result.start).
+     * @return a javascript date object created from the `result.start`.
      */
     date(): Date;
+
+    /**
+     * @return debugging tags combined of the `result.start` and `result.end`.
+     */
+    tags(): Set<string>;
 }
 
 /**
@@ -105,6 +110,11 @@ export interface ParsedComponents {
      * @return a javascript date object.
      */
     date(): Date;
+
+    /**
+     * @return debugging tags of the parsed component.
+     */
+    tags(): Set<string>;
 }
 
 export type Component =

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -5,6 +5,7 @@ import UnlikelyFormatFilter from "../src/common/refiners/UnlikelyFormatFilter";
 import SlashDateFormatParser from "../src/common/parsers/SlashDateFormatParser";
 import ENWeekdayParser from "../src/locales/en/parsers/ENWeekdayParser";
 import ENTimeUnitCasualRelativeFormatParser from "../src/locales/en/parsers/ENTimeUnitCasualRelativeFormatParser";
+import { ParsingComponents } from "../src/";
 
 //-------------------------------------
 
@@ -122,6 +123,42 @@ test("Test - Add custom refiner example", () => {
         expect(result.start.get("hour")).toBe(2);
         expect(result.start.get("minute")).toBe(30);
     });
+});
+
+test("Test - Add custom parser with tags example", () => {
+    const custom = chrono.casual.clone();
+    custom.parsers.push({
+        pattern: () => {
+            return /\bChristmas\b/i;
+        },
+        extract: (context) => {
+            return context
+                .createParsingComponents({
+                    day: 25,
+                    month: 12,
+                })
+                .addTag("CustomParser/chirstmas");
+        },
+    });
+
+    testSingleCase(custom, "Doing something tomorrow", (result) => {
+        expect(result.text).toBe("tomorrow");
+        expect(result.tags()).toContain("ENCasualDateParser/extract/tomorrow");
+    });
+
+    testSingleCase(custom, "I'll arrive at 2.30AM on Christmas", (result) => {
+        expect(result.text).toBe("at 2.30AM on Christmas");
+        expect(result.tags()).toContain("CustomParser/chirstmas");
+        // TODO: Check for time (expression) parsing tags
+    });
+
+    testSingleCase(custom, "I'll arrive at Christmas night", (result) => {
+        expect(result.text).toBe("Christmas night");
+        expect(result.tags()).toContain("CustomParser/chirstmas");
+        // TODO: Check for time (casual) parsing tags
+    });
+
+    // TODO: Check if the merge date range combine tags correctly
 });
 
 test("Test - Remove a parser example", () => {

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -137,25 +137,25 @@ test("Test - Add custom parser with tags example", () => {
                     day: 25,
                     month: 12,
                 })
-                .addTag("CustomParser/chirstmas");
+                .addTag("parser/ChristmasDayParser");
         },
     });
 
     testSingleCase(custom, "Doing something tomorrow", (result) => {
         expect(result.text).toBe("tomorrow");
-        expect(result.tags()).toContain("ENCasualDateParser/extract/tomorrow");
+        expect(result.tags()).toContain("parser/ENCasualDateParser");
     });
 
     testSingleCase(custom, "I'll arrive at 2.30AM on Christmas", (result) => {
         expect(result.text).toBe("at 2.30AM on Christmas");
-        expect(result.tags()).toContain("CustomParser/chirstmas");
-        // TODO: Check for time (expression) parsing tags
+        expect(result.tags()).toContain("parser/ChristmasDayParser");
+        expect(result.tags()).toContain("parser/ENTimeExpressionParser");
     });
 
     testSingleCase(custom, "I'll arrive at Christmas night", (result) => {
         expect(result.text).toBe("Christmas night");
-        expect(result.tags()).toContain("CustomParser/chirstmas");
-        // TODO: Check for time (casual) parsing tags
+        expect(result.tags()).toContain("parser/ChristmasDayParser");
+        expect(result.tags()).toContain("parser/ENCasualTimeParser");
     });
 
     // TODO: Check if the merge date range combine tags correctly


### PR DESCRIPTION
# Parsing Tags

A parsing tag or just "tag" is a string attached to parsed components (and results) by parsers and refiners for additional information about the location and context where components were created or modified.

```typescript
const custom = chrono.casual.clone();
custom.parsers.push({
    pattern: () => { return /\bChristmas\b/i },
    extract: (context, match) => {
        return .createParsingComponents({day: 25, month: 12 })
                .addTag("USHoliday/chirstmas");
    }
});
custom.parsers.push({
    pattern: () => { return /\bNew Year\b/i },
    extract: (context, match) => {
        return .createParsingComponents({day: 1, month: 1 })
                .addTag("USHoliday/new_year");
    }
});

....

const result = custom.parse("I'll arrive at 2.30AM on Christmas night....")[0];

// To recognize the result from a specific parser... 
result.tags().has("CustomHoliday/chirstmas")

// To recognize the result from a specific parser group... 
Array.from(result.tags()).some((t) => t.startsWith("USHoliday/")
Array.from(result.tags()).some((t) => t.match(/EN\w+Parser/)

// To recognize the special content/info from paser
const theHolidayName = Array.from(result.tags())
    .find(t => t.startsWith("USHoliday/"))
   ?.replace("USHoliday/", "");
```

## Potential Usage

### Debugging Extraction: 

Inside Chrono, multiple parsers and refiners work together to produce the result. Identifying which component(s) output the incorrect results is challenging.  

By tagging the result with involved parsers and refiners, it should be easier to identify the area to fix from the bug report or debug log:
```text
Error: Expected date to be: Sat Sep 02 2023 14:29:21 GMT+0900 (Japan Standard Time) Received: Sun Sep 03 2023 14:29:21 GMT+0900 (Japan Standard Time) ([ParsingComponents {
            tags: ["ENCasualDateParser/extract/tomorrow"], 
            knownValues: {"day":3,"month":9,"year":2023}, 
            impliedValues: {"hour":14,"minute":29,"second":21,"millisecond":371}}, 
            reference: {"instant":"2023-09-02T05:29:21.371Z"}])
```

### Recognizing results "types" (or "categories")

These is the list of example ideas:
* Check which parser's method produce the result and treat the output accordingly (e.g. format the output text in #524)
* Check if the output is in which locale (e.g. from "EN-" or common ISO parser)

