### PR TITLE
Improve dutch

### DIFF
--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -6,13 +6,13 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 import { matchAnyPattern } from "../../../utils/pattern";
 
 const PATTERN = new RegExp(
-    `(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
+    `(dit|deze|(?:aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
     "(?=\\W|$)",
     "i"
 );
 
 const MODIFIER_WORD_GROUP = 1;
-const RELATIVE_WORD_GROUP = 3;
+const RELATIVE_WORD_GROUP = 2;
 
 export default class NLRelativeDateFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -6,8 +6,8 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 import { matchAnyPattern } from "../../../utils/pattern";
 
 const PATTERN = new RegExp(
-    `(dit|deze|komende|volgend|volgende|afgelopen|vorige)\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
-        "(?=\\W|$)",
+    `(dit|deze|komend|komende|volgend|volgende|afgelopen|vorige)\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
+    "(?=\\W|$)",
     "i"
 );
 
@@ -24,7 +24,7 @@ export default class NLRelativeDateFormatParser extends AbstractParserWithWordBo
         const unitWord = match[RELATIVE_WORD_GROUP].toLowerCase();
         const timeunit = TIME_UNIT_DICTIONARY[unitWord];
 
-        if (modifier == "volgend" || modifier == "volgende" || modifier == "komende") {
+        if (modifier == "volgend" || modifier == "volgende" || modifier == "komend" || modifier == "komende") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
             return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -6,14 +6,14 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 import { matchAnyPattern } from "../../../utils/pattern";
 
 const PATTERN = new RegExp(
-    `(dit|deze|komend|komende|volgend|volgende|afgelopen|vorige)\\s*(${matchAnyPattern(
+    `(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(
         TIME_UNIT_DICTIONARY
     )})(?=\\s*)` + "(?=\\W|$)",
     "i"
 );
 
 const MODIFIER_WORD_GROUP = 1;
-const RELATIVE_WORD_GROUP = 2;
+const RELATIVE_WORD_GROUP = 3;
 
 export default class NLRelativeDateFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
@@ -25,13 +25,13 @@ export default class NLRelativeDateFormatParser extends AbstractParserWithWordBo
         const unitWord = match[RELATIVE_WORD_GROUP].toLowerCase();
         const timeunit = TIME_UNIT_DICTIONARY[unitWord];
 
-        if (modifier == "volgend" || modifier == "volgende" || modifier == "komend" || modifier == "komende") {
+        if (modifier == "volgend" || modifier == "komend" || modifier == "aankomend") {
             const timeUnits = {};
             timeUnits[timeunit] = 1;
             return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
         }
 
-        if (modifier == "afgelopen" || modifier == "vorige") {
+        if (modifier == "afgelopen" || modifier == "vorig") {
             const timeUnits = {};
             timeUnits[timeunit] = -1;
             return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -6,8 +6,9 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 import { matchAnyPattern } from "../../../utils/pattern";
 
 const PATTERN = new RegExp(
-    `(dit|deze|komend|komende|volgend|volgende|afgelopen|vorige)\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
-    "(?=\\W|$)",
+    `(dit|deze|komend|komende|volgend|volgende|afgelopen|vorige)\\s*(${matchAnyPattern(
+        TIME_UNIT_DICTIONARY
+    )})(?=\\s*)` + "(?=\\W|$)",
     "i"
 );
 

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -5,12 +5,7 @@ import dayjs from "dayjs";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { matchAnyPattern } from "../../../utils/pattern";
 
-const PATTERN = new RegExp(
-    `(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(
-        TIME_UNIT_DICTIONARY
-    )})(?=\\s*)` + "(?=\\W|$)",
-    "i"
-);
+const PATTERN = new RegExp(`(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` + "(?=\\W|$)", "i");
 
 const MODIFIER_WORD_GROUP = 1;
 const RELATIVE_WORD_GROUP = 3;

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -5,7 +5,11 @@ import dayjs from "dayjs";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { matchAnyPattern } from "../../../utils/pattern";
 
-const PATTERN = new RegExp(`(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` + "(?=\\W|$)", "i");
+const PATTERN = new RegExp(
+    `(dit|deze|(aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
+    "(?=\\W|$)",
+    "i"
+);
 
 const MODIFIER_WORD_GROUP = 1;
 const RELATIVE_WORD_GROUP = 3;

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -4,7 +4,10 @@ import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { reverseTimeUnits } from "../../../utils/timeunits";
 
-const PATTERN = new RegExp(`(deze|vorig|vorige|afgelopen|komend|komende|over|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
+const PATTERN = new RegExp(
+    `(deze|vorig|vorige|afgelopen|komend|komende|over|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
+    "i"
+);
 
 export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -4,10 +4,10 @@ import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { reverseTimeUnits } from "../../../utils/timeunits";
 
-const PATTERN = new RegExp(`(dit|deze|vorig|afgelopen|(aan)?komend|over|\\+|-)e?\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
+const PATTERN = new RegExp(`(dit|deze|vorig|afgelopen|(?:aan)?komend|over|\\+|-)e?\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
 
 const PREFIX_WORD_GROUP = 1;
-const TIME_UNIT_WORD_GROUP = 3;
+const TIME_UNIT_WORD_GROUP = 2;
 
 export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -4,10 +4,10 @@ import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { reverseTimeUnits } from "../../../utils/timeunits";
 
-const PATTERN = new RegExp(
-    `(deze|vorig|vorige|afgelopen|komend|komende|over|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
-    "i"
-);
+const PATTERN = new RegExp(`(dit|deze|vorig|afgelopen|(aan)?komend|over|\\+|-)e?\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
+
+const PREFIX_WORD_GROUP = 1;
+const TIME_UNIT_WORD_GROUP = 3;
 
 export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
@@ -15,11 +15,10 @@ export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParser
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
-        const prefix = match[1].toLowerCase();
-        let timeUnits = parseTimeUnits(match[2]);
+        const prefix = match[PREFIX_WORD_GROUP].toLowerCase();
+        let timeUnits = parseTimeUnits(match[TIME_UNIT_WORD_GROUP]);
         switch (prefix) {
             case "vorig":
-            case "vorige":
             case "afgelopen":
             case "-":
                 timeUnits = reverseTimeUnits(timeUnits);

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -4,7 +4,7 @@ import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { reverseTimeUnits } from "../../../utils/timeunits";
 
-const PATTERN = new RegExp(`(deze|vorige|afgelopen|komende|over|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
+const PATTERN = new RegExp(`(deze|vorig|vorige|afgelopen|komend|komende|over|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`, "i");
 
 export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
     innerPattern(): RegExp {
@@ -15,6 +15,7 @@ export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParser
         const prefix = match[1].toLowerCase();
         let timeUnits = parseTimeUnits(match[2]);
         switch (prefix) {
+            case "vorig":
             case "vorige":
             case "afgelopen":
             case "-":

--- a/test/nl/nl_relative.test.ts
+++ b/test/nl/nl_relative.test.ts
@@ -98,7 +98,7 @@ test("Test - Future relative expressions", () => {
     });
 
     // next month
-    testSingleCase(chrono.nl, "volgende maand", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "aankomende maand", new Date(2016, 10 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(11);

--- a/test/nl/nl_relative.test.ts
+++ b/test/nl/nl_relative.test.ts
@@ -71,7 +71,7 @@ test("Test - Past relative expressions", () => {
 
 test("Test - Future relative expressions", () => {
     // next hour
-    testSingleCase(chrono.nl, "komende uur", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+    testSingleCase(chrono.nl, "komend uur", new Date(2016, 10 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);
@@ -137,7 +137,7 @@ test("Test - Relative date components' certainty", () => {
     const refDate = new Date(2016, 10 - 1, 7, 12);
 
     // next hour
-    testSingleCase(chrono.nl, "komende uur", refDate, (result, text) => {
+    testSingleCase(chrono.nl, "komend uur", refDate, (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);
         expect(result.start.get("month")).toBe(10);

--- a/test/nl/nl_relative.test.ts
+++ b/test/nl/nl_relative.test.ts
@@ -98,6 +98,20 @@ test("Test - Future relative expressions", () => {
     });
 
     // next month
+    testSingleCase(chrono.nl, "volgende maand", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(11);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+        expect(result.start.isCertain("hour")).toBe(false);
+    });
+
+    // next month
     testSingleCase(chrono.nl, "aankomende maand", new Date(2016, 10 - 1, 1, 12), (result, text) => {
         expect(result.text).toBe(text);
         expect(result.start.get("year")).toBe(2016);


### PR DESCRIPTION
Correct in Dutch is "komend uur", not "komende uur".  
And there are some other combinations that were not detected yet: "aankomende maand", "komend jaar" and some more.

In this PR both  
"komend" and "komende",  
"volgend" and "volgende",  
"vorig" and "vorige",
"aankomend" and "aankomende"  
are allowed.

Changed test for "volgende maand" into "aankomende maand", as there are already tests for "volgende week", "volgende dag", "volgend jaar" and no tests for "aankomende".