### PR TITLE
[EN] Fix for multiple time units within parser (e.g. set a timer for 5 minutes and 30 seconds)

### DIFF
--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -3,15 +3,19 @@ import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 
+const TIME_UNIT_PATTERN = `(${TIME_UNITS_PATTERN})`;
+const TIME_UNIT_CONNECTOR_PATTERN = `\\s+and\\s+`;
+const MULTIPLE_TIME_UNITS_PATTERN = `${TIME_UNIT_PATTERN}(?:${TIME_UNIT_CONNECTOR_PATTERN}${TIME_UNIT_PATTERN})*`;
+
 const PATTERN_WITH_OPTIONAL_PREFIX = new RegExp(
     `(?:(?:within|in|for)\\s*)?` +
-        `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?(${TIME_UNITS_PATTERN})(?=\\W|$)`,
+    `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?${MULTIPLE_TIME_UNITS_PATTERN}(?=\\W|$)`,
     "i"
 );
 
 const PATTERN_WITH_PREFIX = new RegExp(
     `(?:within|in|for)\\s*` +
-        `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?(${TIME_UNITS_PATTERN})(?=\\W|$)`,
+        `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?(${MULTIPLE_TIME_UNITS_PATTERN})(?=\\W|$)`,
     "i"
 );
 

--- a/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
+++ b/src/locales/en/parsers/ENTimeUnitWithinFormatParser.ts
@@ -9,7 +9,7 @@ const MULTIPLE_TIME_UNITS_PATTERN = `${TIME_UNIT_PATTERN}(?:${TIME_UNIT_CONNECTO
 
 const PATTERN_WITH_OPTIONAL_PREFIX = new RegExp(
     `(?:(?:within|in|for)\\s*)?` +
-    `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?${MULTIPLE_TIME_UNITS_PATTERN}(?=\\W|$)`,
+    `(?:(?:about|around|roughly|approximately|just)\\s*(?:~\\s*)?)?(${MULTIPLE_TIME_UNITS_PATTERN})(?=\\W|$)`,
     "i"
 );
 

--- a/test/en/en_time_units_within.test.ts
+++ b/test/en/en_time_units_within.test.ts
@@ -60,6 +60,13 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19, 30));
     });
 
+    testSingleCase(chrono, "set a timer for 10 minutes and 10 seconds", new Date(2012, 7, 10, 12, 14), { forwardDate: true },  (result) => {
+        expect(result.index).toBe(12);
+        expect(result.text).toBe("for 10 minutes and 10 seconds");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 24, 10));
+    });
+
     testSingleCase(chrono, "within 1 hour", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("within 1 hour");

--- a/test/en/en_time_units_within.test.ts
+++ b/test/en/en_time_units_within.test.ts
@@ -53,6 +53,13 @@ test("Test - The normal within expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
     });
 
+    testSingleCase(chrono, "set a timer for 5 minutes and 30 seconds", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(12);
+        expect(result.text).toBe("for 5 minutes and 30 seconds");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19, 30));
+    });
+
     testSingleCase(chrono, "within 1 hour", new Date(2012, 7, 10, 12, 14), (result) => {
         expect(result.index).toBe(0);
         expect(result.text).toBe("within 1 hour");


### PR DESCRIPTION
I ran into issues with phrases like "for 5 minutes AND 30 seconds". It seems the regex didn't capture the second time unit. I updated the regex to capture multiple time units in ENTimeUnitWithinFormatParser. I also added a test case. I hope this is acceptable. If not let me know.
