### PR TITLE
Test: add more testing around 'for the' case

### DIFF
--- a/test/en/en_month.test.ts
+++ b/test/en/en_month.test.ts
@@ -71,7 +71,10 @@ test("Test - Month-Year expression", function () {
 
     testSingleCase(chrono, "Statement of comprehensive income for the year ended Dec. 2021", (result) => {
         expect(result.start.get("year")).toBe(2021);
+        expect(result.start.isCertain("year")).toBe(true);
         expect(result.start.get("month")).toBe(12);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
         expect(result.text).toBe("Dec. 2021");
     });
 });


### PR DESCRIPTION
**Done:**
Adding more checks to a test. For the text "_Statement of comprehensive income for the year ended Dec. 2021_" the year and the month should be certain, but not the day. Currently it's extracting the _20_ from _2021_ as a certain day, but that's incorrect.