### PR TITLE
Fix parseDate return type not nullable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,6 @@ export function parse(text: string, ref?: ParsingReference | Date, option?: Pars
 /**
  * A shortcut for {@link en | chrono.en.casual.parseDate()}
  */
-export function parseDate(text: string, ref?: ParsingReference | Date, option?: ParsingOption): Date {
+export function parseDate(text: string, ref?: ParsingReference | Date, option?: ParsingOption): Date | null {
     return casual.parseDate(text, ref, option);
 }


### PR DESCRIPTION
Fix `parseDate` returning `Date` instead of `Date | null` in its types.

Setting `"strictNullChecks": true` in `tsconfig.json` will prevent regressions, but that requires some refactoring to satisfy. There are a handful of places that:
- Expect `null` but get a value that could be `undefined`
- Expect `undefined` but get a value that could be `null`
- Expect a non-nullish type but get a value that could be nullish