### PR TITLE
Fix: timezone option for relative dates should affect time

### DIFF
--- a/src/results.ts
+++ b/src/results.ts
@@ -227,7 +227,7 @@ export class ParsingComponents implements ParsedComponents {
         } else {
             implySimilarTime(components, date);
             if (reference.timezoneOffset !== null) {
-                components.imply("timezoneOffset", -reference.instant.getTimezoneOffset());
+                components.imply("timezoneOffset", reference.timezoneOffset ?? -reference.instant.getTimezoneOffset());
             }
 
             if (fragments["d"]) {

--- a/test/en/en.test.ts
+++ b/test/en/en.test.ts
@@ -189,3 +189,22 @@ test("Test - Customize by removing time extraction", () => {
         expect(result.start.get("day")).toBe(26);
     });
 });
+
+test("Test - Timezone handling in relative dates", () => {
+    const refDate = new Date(2025, 2 - 1, 27, 12, 0); // Feb 27, 2025 12:00
+
+    testSingleCase(chrono, "in 2 weeks at 9am", { instant: refDate, timezone: "PST" }, (result) => {
+        expect(result.text).toBe("in 2 weeks at 9am");
+        expect(result.start.get("hour")).toBe(9);
+        expect(result.start.get("timezoneOffset")).toBe(-480);
+        expect(result.start).toBeDate(new Date(2025, 3 - 1, 13, 17, 0));
+    });
+
+    testSingleCase(chrono, "2 weeks ago at 9am", { instant: refDate, timezone: "PST" }, (result) => {
+        expect(result.text).toBe("2 weeks ago at 9am");
+        expect(result.start.get("hour")).toBe(9);
+        expect(result.start.get("timezoneOffset")).toBe(-480);
+        expect(result.start).toBeDate(new Date(2025, 2 - 1, 13, 17, 0));
+    });
+});
+


### PR DESCRIPTION
Addressing #582 

I'm not intimately familiar with all of the logic going on here, but tests pass, so I'm hoping you'll find this to be a suitable solution.

Also added 2 tests which address these cases. I added them in the main en locale test file; I'm not sure if there's a better spot for them.