### PR TITLE
Improve Japanese

### DIFF
--- a/src/locales/ja/parsers/JPCasualDateParser.ts
+++ b/src/locales/ja/parsers/JPCasualDateParser.ts
@@ -3,12 +3,14 @@ import dayjs from "dayjs";
 import { Meridiem } from "../../../types";
 import * as references from "../../../common/casualReferences";
 
-const PATTERN = /今日|きょう|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
+const PATTERN = /今日|きょう|本日|ほんじつ|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
 
 function normalizeTextToKanji(text: string) {
     switch (text) {
         case "きょう":
             return "今日";
+        case "ほんじつ":
+            return "本日";
         case "きのう":
             return "昨日";
         case "あした":
@@ -44,6 +46,7 @@ export default class JPCasualDateParser implements Parser {
             case "明日":
                 return references.tomorrow(context.reference);
 
+            case "本日":
             case "今日":
                 return references.today(context.reference);
         }

--- a/src/locales/ja/parsers/JPCasualDateParser.ts
+++ b/src/locales/ja/parsers/JPCasualDateParser.ts
@@ -3,14 +3,12 @@ import dayjs from "dayjs";
 import { Meridiem } from "../../../types";
 import * as references from "../../../common/casualReferences";
 
-const PATTERN = /今日|きょう|当日|とうじつ|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
+const PATTERN = /今日|きょう|昨日|きのう|明日|あした|今夜|こんや|今夕|こんゆう|今晩|こんばん|今朝|けさ/i;
 
 function normalizeTextToKanji(text: string) {
     switch (text) {
         case "きょう":
             return "今日";
-        case "とうじつ":
-            return "当日";
         case "きのう":
             return "昨日";
         case "あした":
@@ -47,7 +45,6 @@ export default class JPCasualDateParser implements Parser {
                 return references.tomorrow(context.reference);
 
             case "今日":
-            case "当日":
                 return references.today(context.reference);
         }
 

--- a/src/locales/ja/refiners/JPMergeDateRangeRefiner.ts
+++ b/src/locales/ja/refiners/JPMergeDateRangeRefiner.ts
@@ -8,6 +8,6 @@ import AbstractMergeDateRangeRefiner from "../../../common/refiners/AbstractMerg
  */
 export default class JPMergeDateRangeRefiner extends AbstractMergeDateRangeRefiner {
     patternBetween(): RegExp {
-        return /^\s*(から|ー|-)\s*$/i;
+        return /^\s*(から|ー|-|～|~)\s*$/i;
     }
 }

--- a/test/ja/ja_casual.test.ts
+++ b/test/ja/ja_casual.test.ts
@@ -10,6 +10,14 @@ test("Test - Single Expression", function () {
         expect(result.text).toBe("きょう");
         expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
     });
+    testSingleCase(chrono.ja, "本日はお日柄もよく", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("本日");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
+    testSingleCase(chrono.ja, "ほんじつはお日柄もよく", new Date(2012, 8 - 1, 10, 12), (result) => {
+        expect(result.text).toBe("ほんじつ");
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+    });
 
     testSingleCase(chrono.ja, "昨日の全国観測値ランキング", new Date(2012, 8 - 1, 10, 12), (result) => {
         expect(result.text).toBe("昨日");

--- a/test/ja/ja_standard.test.ts
+++ b/test/ja/ja_standard.test.ts
@@ -213,4 +213,23 @@ test("Test - Range Expression", function () {
 
         expect(result.end).toBeDate(new Date(2014, 1 - 1, 7, 12));
     });
+
+    testSingleCase(chrono.ja, "2013年12月26日 ～ ２０１４年１月７日", new Date(2012, 8 - 1, 10), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("2013年12月26日 ～ ２０１４年１月７日");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(26);
+
+        expect(result.start).toBeDate(new Date(2013, 12 - 1, 26, 12));
+
+        expect(result.end).not.toBeNull();
+        expect(result.end.get("year")).toBe(2014);
+        expect(result.end.get("month")).toBe(1);
+        expect(result.end.get("day")).toBe(7);
+
+        expect(result.end).toBeDate(new Date(2014, 1 - 1, 7, 12));
+    });
 });


### PR DESCRIPTION
## Changes

- I removed "当日" on `JPCasualDateParser`. Because "当日" means that day or the day, not today.  
- I added "本日" as today on `JPCasualDateParser`
- I added "~" and "～" as patternBetween on `JPMergeDateRangeRefiner`. They are often used in Japanese.