### PR TITLE
Fix: Do not parse year-like numbers as times

### DIFF
--- a/src/common/parsers/AbstractTimeExpressionParser.ts
+++ b/src/common/parsers/AbstractTimeExpressionParser.ts
@@ -140,6 +140,12 @@ export abstract class AbstractTimeExpressionParser implements Parser {
         // ----- Hours
         let hour = parseInt(match[HOUR_GROUP]);
         if (hour > 100) {
+            // When time is like '2019', it is more likely a year.
+            // Especially if there is no minute part and no am/pm.
+            if (match[HOUR_GROUP].length == 4 && match[MINUTE_GROUP] == null && !match[AM_PM_HOUR_GROUP]) {
+                return null;
+            }
+
             if (this.strictMode || match[MINUTE_GROUP] != null) {
                 return null;
             }

--- a/test/en/en_time_exp.test.ts
+++ b/test/en/en_time_exp.test.ts
@@ -432,6 +432,8 @@ test("Test - Parsing negative cases : [year-like] pattern", function () {
     testUnexpectedResult(chrono, "2020");
 
     testUnexpectedResult(chrono, "2020  ");
+
+    testUnexpectedResult(chrono, "2019 to 2020");
 });
 
 test("Test - Parsing negative cases : 'at [some numbers]'", function () {


### PR DESCRIPTION
The `AbstractTimeExpressionParser` was incorrectly parsing 4-digit numbers as times (e.g., '2019' as 20:19). This caused issues with year ranges like '2019 to 2020' being parsed as a time.

This change adds a check to the parser to prevent this. A 4-digit number is no longer considered a time if it is not accompanied by a minute part or an AM/PM specifier.

A test case has been added to ensure that '2019 to 2020' is not parsed as a time.