### PR TITLE
Refactor: Remove deprecated timeunits.reverseTimeUnits

### DIFF
--- a/src/locales/de/parsers/DETimeUnitRelativeFormatParser.ts
+++ b/src/locales/de/parsers/DETimeUnitRelativeFormatParser.ts
@@ -2,8 +2,8 @@ import { ParsingContext } from "../../../chrono";
 import { NUMBER_PATTERN, parseNumberPattern, TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { matchAnyPattern } from "../../../utils/pattern";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class DETimeUnitAgoFormatParser extends AbstractParserWithWordBoundaryChecking {
     constructor() {
@@ -34,7 +34,7 @@ export default class DETimeUnitAgoFormatParser extends AbstractParserWithWordBou
         }
 
         if (/vor/.test(modifier) || /letzte/.test(modifier) || /vergangen/.test(modifier)) {
-            timeUnits = reverseTimeUnits(timeUnits);
+            timeUnits = reverseDuration(timeUnits);
         }
 
         return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);

--- a/src/locales/en/refiners/ENMergeRelativeAfterDateRefiner.ts
+++ b/src/locales/en/refiners/ENMergeRelativeAfterDateRefiner.ts
@@ -1,7 +1,7 @@
 import { MergingRefiner } from "../../../common/abstractRefiners";
 import { ParsingComponents, ParsingResult, ReferenceWithTimezone } from "../../../results";
 import { parseTimeUnits } from "../constants";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 function IsPositiveFollowingReference(result: ParsingResult): boolean {
     return result.text.match(/^[+-]/i) != null;
@@ -28,7 +28,7 @@ export default class ENMergeRelativeAfterDateRefiner extends MergingRefiner {
     mergeResults(textBetween: string, currentResult: ParsingResult, nextResult: ParsingResult, context): ParsingResult {
         let timeUnits = parseTimeUnits(nextResult.text);
         if (IsNegativeFollowingReference(nextResult)) {
-            timeUnits = reverseTimeUnits(timeUnits);
+            timeUnits = reverseDuration(timeUnits);
         }
 
         const components = ParsingComponents.createRelativeFromReference(

--- a/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitAgoFormatParser.ts
@@ -2,7 +2,7 @@ import { ParsingContext } from "../../../chrono";
 import { parseTimeUnits, TIME_UNITS_PATTERN } from "../constants";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBoundaryChecking {
     constructor() {
@@ -15,7 +15,7 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const timeUnits = parseTimeUnits(match[1]);
-        const outputTimeUnits = reverseTimeUnits(timeUnits);
+        const outputTimeUnits = reverseDuration(timeUnits);
 
         return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }

--- a/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
+++ b/src/locales/fr/parsers/FRTimeUnitRelativeFormatParser.ts
@@ -2,8 +2,8 @@ import { ParsingContext } from "../../../chrono";
 import { NUMBER_PATTERN, parseNumberPattern, TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { matchAnyPattern } from "../../../utils/pattern";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBoundaryChecking {
     constructor() {
@@ -35,7 +35,7 @@ export default class FRTimeUnitAgoFormatParser extends AbstractParserWithWordBou
         }
 
         if (/derni[eè]re?s?/.test(modifier) || /pass[ée]e?s?/.test(modifier) || /pr[ée]c[ée]dents?/.test(modifier)) {
-            timeUnits = reverseTimeUnits(timeUnits);
+            timeUnits = reverseDuration(timeUnits);
         }
 
         return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);

--- a/src/locales/it/parsers/ITTimeUnitAgoFormatParser.ts
+++ b/src/locales/it/parsers/ITTimeUnitAgoFormatParser.ts
@@ -2,7 +2,7 @@ import { ParsingContext } from "../../../chrono";
 import { parseTimeUnits, TIME_UNITS_PATTERN } from "../constants";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 const PATTERN = new RegExp(`(${TIME_UNITS_PATTERN})\\s{0,5}(?:fa|prima|precedente)(?=(?:\\W|$))`, "i");
 const STRICT_PATTERN = new RegExp(`(${TIME_UNITS_PATTERN})\\s{0,5}fa(?=(?:\\W|$))`, "i");
@@ -18,7 +18,7 @@ export default class ENTimeUnitAgoFormatParser extends AbstractParserWithWordBou
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const timeUnits = parseTimeUnits(match[1]);
-        const outputTimeUnits = reverseTimeUnits(timeUnits);
+        const outputTimeUnits = reverseDuration(timeUnits);
 
         return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }

--- a/src/locales/it/parsers/ITTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/it/parsers/ITTimeUnitCasualRelativeFormatParser.ts
@@ -2,7 +2,7 @@ import { TIME_UNITS_PATTERN, parseTimeUnits } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 const PATTERN = new RegExp(
     `(questo|ultimo|passato|prossimo|dopo|questa|ultima|passata|prossima|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
@@ -21,7 +21,7 @@ export default class ENTimeUnitCasualRelativeFormatParser extends AbstractParser
             case "last":
             case "past":
             case "-":
-                timeUnits = reverseTimeUnits(timeUnits);
+                timeUnits = reverseDuration(timeUnits);
                 break;
         }
 

--- a/src/locales/it/refiners/ITMergeRelativeDateRefiner.ts
+++ b/src/locales/it/refiners/ITMergeRelativeDateRefiner.ts
@@ -1,7 +1,7 @@
 import { MergingRefiner } from "../../../common/abstractRefiners";
 import { ParsingComponents, ParsingResult, ReferenceWithTimezone } from "../../../results";
 import { parseTimeUnits } from "../constants";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 function hasImpliedEarlierReferenceDate(result: ParsingResult): boolean {
     return result.text.match(/\s+(prima|dal)$/i) != null;
@@ -40,7 +40,7 @@ export default class ENMergeRelativeDateRefiner extends MergingRefiner {
     mergeResults(textBetween: string, currentResult: ParsingResult, nextResult: ParsingResult): ParsingResult {
         let timeUnits = parseTimeUnits(currentResult.text);
         if (hasImpliedEarlierReferenceDate(currentResult)) {
-            timeUnits = reverseTimeUnits(timeUnits);
+            timeUnits = reverseDuration(timeUnits);
         }
 
         const components = ParsingComponents.createRelativeFromReference(

--- a/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitAgoFormatParser.ts
@@ -2,7 +2,7 @@ import { ParsingContext } from "../../../chrono";
 import { parseTimeUnits, TIME_UNITS_PATTERN } from "../constants";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 const PATTERN = new RegExp("" + "(" + TIME_UNITS_PATTERN + ")" + "(?:geleden|voor|eerder)(?=(?:\\W|$))", "i");
 
@@ -19,7 +19,7 @@ export default class NLTimeUnitAgoFormatParser extends AbstractParserWithWordBou
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const timeUnits = parseTimeUnits(match[1]);
-        const outputTimeUnits = reverseTimeUnits(timeUnits);
+        const outputTimeUnits = reverseDuration(timeUnits);
 
         return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }

--- a/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/nl/parsers/NLTimeUnitCasualRelativeFormatParser.ts
@@ -2,7 +2,7 @@ import { TIME_UNITS_PATTERN, parseTimeUnits } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
-import { reverseTimeUnits } from "../../../utils/timeunits";
+import { reverseDuration } from "../../../calculation/duration";
 
 const PATTERN = new RegExp(
     `(dit|deze|vorig|afgelopen|(?:aan)?komend|over|\\+|-)e?\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
@@ -24,7 +24,7 @@ export default class NLTimeUnitCasualRelativeFormatParser extends AbstractParser
             case "vorig":
             case "afgelopen":
             case "-":
-                timeUnits = reverseTimeUnits(timeUnits);
+                timeUnits = reverseDuration(timeUnits);
                 break;
         }
 

--- a/src/locales/ru/parsers/RUTimeUnitAgoFormatParser.ts
+++ b/src/locales/ru/parsers/RUTimeUnitAgoFormatParser.ts
@@ -1,8 +1,8 @@
 import { ParsingContext } from "../../../chrono";
 import { parseTimeUnits, TIME_UNITS_PATTERN } from "../constants";
 import { ParsingComponents } from "../../../results";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { AbstractParserWithLeftBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class RUTimeUnitAgoFormatParser extends AbstractParserWithLeftBoundaryChecking {
     innerPatternString(context: ParsingContext): string {
@@ -11,7 +11,7 @@ export default class RUTimeUnitAgoFormatParser extends AbstractParserWithLeftBou
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const timeUnits = parseTimeUnits(match[1]);
-        const outputTimeUnits = reverseTimeUnits(timeUnits);
+        const outputTimeUnits = reverseDuration(timeUnits);
 
         return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }

--- a/src/locales/ru/parsers/RUTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/ru/parsers/RUTimeUnitCasualRelativeFormatParser.ts
@@ -1,8 +1,8 @@
 import { TIME_UNITS_PATTERN, parseTimeUnits, REGEX_PARTS } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { AbstractParserWithLeftRightBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class RUTimeUnitCasualRelativeFormatParser extends AbstractParserWithLeftRightBoundaryChecking {
     innerPatternString(context: ParsingContext): string {
@@ -16,7 +16,7 @@ export default class RUTimeUnitCasualRelativeFormatParser extends AbstractParser
             case "последние":
             case "прошлые":
             case "-":
-                timeUnits = reverseTimeUnits(timeUnits);
+                timeUnits = reverseDuration(timeUnits);
                 break;
         }
 

--- a/src/locales/uk/parsers/UKTimeUnitAgoFormatParser.ts
+++ b/src/locales/uk/parsers/UKTimeUnitAgoFormatParser.ts
@@ -1,8 +1,8 @@
 import { ParsingContext } from "../../../chrono";
 import { parseTimeUnits, TIME_UNITS_PATTERN } from "../constants";
 import { ParsingComponents } from "../../../results";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { AbstractParserWithLeftBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class UKTimeUnitAgoFormatParser extends AbstractParserWithLeftBoundaryChecking {
     innerPatternString(context: ParsingContext): string {
@@ -11,7 +11,7 @@ export default class UKTimeUnitAgoFormatParser extends AbstractParserWithLeftBou
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const timeUnits = parseTimeUnits(match[1]);
-        const outputTimeUnits = reverseTimeUnits(timeUnits);
+        const outputTimeUnits = reverseDuration(timeUnits);
 
         return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
     }

--- a/src/locales/uk/parsers/UKTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/uk/parsers/UKTimeUnitCasualRelativeFormatParser.ts
@@ -1,8 +1,8 @@
 import { TIME_UNITS_PATTERN, parseTimeUnits, REGEX_PARTS } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import { reverseTimeUnits } from "../../../utils/timeunits";
 import { AbstractParserWithLeftRightBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { reverseDuration } from "../../../calculation/duration";
 
 export default class UKTimeUnitCasualRelativeFormatParser extends AbstractParserWithLeftRightBoundaryChecking {
     innerPatternString(context: ParsingContext): string {
@@ -16,7 +16,7 @@ export default class UKTimeUnitCasualRelativeFormatParser extends AbstractParser
             case "останні":
             case "минулі":
             case "-":
-                timeUnits = reverseTimeUnits(timeUnits);
+                timeUnits = reverseDuration(timeUnits);
                 break;
         }
 

--- a/src/utils/timeunits.ts
+++ b/src/utils/timeunits.ts
@@ -5,16 +5,3 @@ import { ParsingComponents } from "../results";
  * @deprecated Use `calculation.duration.Duration`.
  */
 export type TimeUnits = { [c in OpUnitType | QUnitType]?: number };
-
-/**
- * @deprecated Use `calculation.duration.*`.
- */
-export function reverseTimeUnits(timeUnits: TimeUnits): TimeUnits {
-    const reversed = {};
-    for (const key in timeUnits) {
-        // noinspection JSUnfilteredForInLoop
-        reversed[key] = -timeUnits[key];
-    }
-
-    return reversed as TimeUnits;
-}


### PR DESCRIPTION
Replaced all usages of the deprecated `timeunits.reverseTimeUnits` function with `duration.reverseDuration` from the calculation utilities.

This change affects parsers and refiners across multiple locales that handle relative time expressions. The deprecated function has been removed from the codebase.