### PR TITLE
Refactor: Remove dayjs from src/locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "^3.5.3",
         "rimraf": "^6.0.1",
         "run-script-os": "^1.1.6",
-        "ts-jest": "^29.3.4",
+        "ts-jest": "^29.4.1",
         "tsc-esm-fix": "^3.1.2",
         "typedoc": "^0.28.4",
         "typescript": "~5.8.3"
@@ -2051,13 +2051,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2660,22 +2653,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.157",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
@@ -3128,29 +3105,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3423,6 +3377,28 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3821,49 +3797,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -4855,6 +4788,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4876,6 +4819,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5875,16 +5825,15 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
-      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -5900,10 +5849,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -5920,6 +5870,9 @@
           "optional": true
         },
         "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
           "optional": true
         }
       }
@@ -6077,6 +6030,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6195,6 +6162,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "run-script-os": "^1.1.6",
-    "ts-jest": "^29.3.4",
+    "ts-jest": "^29.4.1",
     "tsc-esm-fix": "^3.1.2",
     "typedoc": "^0.28.4",
     "typescript": "~5.8.3"

--- a/src/locales/de/constants.ts
+++ b/src/locales/de/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     "sonntag": 0,
@@ -86,7 +86,7 @@ export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
     "zwoelf": 12,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     sek: "second",
     sekunde: "second",
     sekunden: "second",
@@ -97,9 +97,9 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     std: "hour",
     stunde: "hour",
     stunden: "hour",
-    tag: "d",
-    tage: "d",
-    tagen: "d",
+    tag: "day",
+    tage: "day",
+    tagen: "day",
     woche: "week",
     wochen: "week",
     monat: "month",

--- a/src/locales/en/constants.ts
+++ b/src/locales/en/constants.ts
@@ -1,8 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
-import { Weekday } from "../../types";
+import { Timeunit, Weekday } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: Weekday } = {
     sunday: 0,
@@ -134,15 +133,15 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "thirty-first": 31,
 };
 
-export const TIME_UNIT_DICTIONARY_NO_ABBR: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY_NO_ABBR: { [word: string]: Timeunit } = {
     second: "second",
     seconds: "second",
     minute: "minute",
     minutes: "minute",
     hour: "hour",
     hours: "hour",
-    day: "d",
-    days: "d",
+    day: "day",
+    days: "day",
     week: "week",
     weeks: "week",
     month: "month",
@@ -153,7 +152,7 @@ export const TIME_UNIT_DICTIONARY_NO_ABBR: { [word: string]: OpUnitType | QUnitT
     years: "year",
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     s: "second",
     sec: "second",
     second: "second",
@@ -168,10 +167,10 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     hrs: "hour",
     hour: "hour",
     hours: "hour",
-    d: "d",
-    day: "d",
-    days: "d",
-    w: "w",
+    d: "day",
+    day: "day",
+    days: "day",
+    w: "week",
     week: "week",
     weeks: "week",
     mo: "month",

--- a/src/locales/es/constants.ts
+++ b/src/locales/es/constants.ts
@@ -1,5 +1,5 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     "domingo": 0,
@@ -78,7 +78,7 @@ export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
     "trece": 13,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     "sec": "second",
     "segundo": "second",
     "segundos": "second",
@@ -91,8 +91,8 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     "hrs": "hour",
     "hora": "hour",
     "horas": "hour",
-    "día": "d",
-    "días": "d",
+    "día": "day",
+    "días": "day",
     "semana": "week",
     "semanas": "week",
     "mes": "month",

--- a/src/locales/fr/constants.ts
+++ b/src/locales/fr/constants.ts
@@ -1,5 +1,5 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     "dimanche": 0,
@@ -76,7 +76,7 @@ export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
     "treize": 13,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     "sec": "second",
     "seconde": "second",
     "secondes": "second",
@@ -89,8 +89,8 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     "hrs": "hour",
     "heure": "hour",
     "heures": "hour",
-    "jour": "d",
-    "jours": "d",
+    "jour": "day",
+    "jours": "day",
     "semaine": "week",
     "semaines": "week",
     "mois": "month",

--- a/src/locales/it/constants.ts
+++ b/src/locales/it/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     "domenica": 0,
@@ -115,7 +115,7 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "trentunesimo": 31,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     "sec": "second",
     "secondo": "second",
     "secondi": "second",
@@ -127,8 +127,8 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     "o": "hour",
     "ora": "hour",
     "ore": "hour",
-    "giorno": "d",
-    "giorni": "d",
+    "giorno": "day",
+    "giorni": "day",
     "settimana": "week",
     "settimane": "week",
     "mese": "month",

--- a/src/locales/it/parsers/ITRelativeDateFormatParser.ts
+++ b/src/locales/it/parsers/ITRelativeDateFormatParser.ts
@@ -1,9 +1,9 @@
 import { TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import dayjs from "dayjs";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { matchAnyPattern } from "../../../utils/pattern";
+import { addImpliedTimeUnits } from "../../../utils/timeunits";
 
 const PATTERN = new RegExp(
     `(questo|ultimo|scorso|prossimo|dopo\\s*questo|questa|ultima|scorsa|prossima\\s*questa)\\s*(${matchAnyPattern(
@@ -38,34 +38,35 @@ export default class ITRelativeDateFormatParser extends AbstractParserWithWordBo
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.reference.instant);
+        let date = new Date(context.reference.instant.getTime());
 
         // This week
         if (unitWord.match(/settimana/i)) {
-            date = date.add(-date.get("d"), "d");
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.imply("year", date.year());
+            date.setDate(date.getDate() - date.getDay());
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.imply("year", date.getFullYear());
         }
 
         // This month
         else if (unitWord.match(/mese/i)) {
-            date = date.add(-date.date() + 1, "d");
-            components.imply("day", date.date());
-            components.assign("year", date.year());
-            components.assign("month", date.month() + 1);
+            date.setDate(1);
+            components.imply("day", date.getDate());
+            components.assign("year", date.getFullYear());
+            components.assign("month", date.getMonth() + 1);
         }
 
         // This year
         else if (unitWord.match(/anno/i)) {
-            date = date.add(-date.date() + 1, "d");
-            date = date.add(-date.month(), "month");
-
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.assign("year", date.year());
+            date.setDate(1);
+            date.setMonth(0);
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.assign("year", date.getFullYear());
         }
 
-        return components;
+        return addImpliedTimeUnits(components, {
+            hour: 12,
+        });
     }
 }

--- a/src/locales/ja/parsers/JPCasualDateParser.ts
+++ b/src/locales/ja/parsers/JPCasualDateParser.ts
@@ -1,5 +1,4 @@
 import { Parser, ParsingContext } from "../../../chrono";
-import dayjs from "dayjs";
 import { Meridiem } from "../../../types";
 import * as references from "../../../common/casualReferences";
 
@@ -36,7 +35,6 @@ export default class JPCasualDateParser implements Parser {
     extract(context: ParsingContext, match: RegExpMatchArray) {
         const text = normalizeTextToKanji(match[0]);
 
-        const date = dayjs(context.refDate);
         const components = context.createParsingComponents();
 
         switch (text) {
@@ -59,9 +57,10 @@ export default class JPCasualDateParser implements Parser {
             components.assign("meridiem", Meridiem.AM);
         }
 
-        components.assign("day", date.date());
-        components.assign("month", date.month() + 1);
-        components.assign("year", date.year());
+        const date = context.refDate;
+        components.assign("day", date.getDate());
+        components.assign("month", date.getMonth() + 1);
+        components.assign("year", date.getFullYear());
         return components;
     }
 }

--- a/src/locales/nl/constants.ts
+++ b/src/locales/nl/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     // Zondag
@@ -136,7 +136,7 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "eenendertigste": 31,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     sec: "second",
     second: "second",
     seconden: "second",
@@ -152,8 +152,8 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType } = {
     uur: "hour",
     u: "hour",
     uren: "hour",
-    dag: "d",
-    dagen: "d",
+    dag: "day",
+    dagen: "day",
     week: "week",
     weken: "week",
     maand: "month",

--- a/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
+++ b/src/locales/nl/parsers/NLRelativeDateFormatParser.ts
@@ -1,9 +1,9 @@
 import { TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import dayjs from "dayjs";
 import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { matchAnyPattern } from "../../../utils/pattern";
+import { addImpliedTimeUnits } from "../../../utils/timeunits";
 
 const PATTERN = new RegExp(
     `(dit|deze|(?:aan)?komend|volgend|afgelopen|vorig)e?\\s*(${matchAnyPattern(TIME_UNIT_DICTIONARY)})(?=\\s*)` +
@@ -37,34 +37,35 @@ export default class NLRelativeDateFormatParser extends AbstractParserWithWordBo
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.reference.instant);
+        let date = new Date(context.reference.instant.getTime());
 
         // This week
         if (unitWord.match(/week/i)) {
-            date = date.add(-date.get("d"), "d");
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.imply("year", date.year());
+            date.setDate(date.getDate() - date.getDay());
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.imply("year", date.getFullYear());
         }
 
         // This month
         else if (unitWord.match(/maand/i)) {
-            date = date.add(-date.date() + 1, "d");
-            components.imply("day", date.date());
-            components.assign("year", date.year());
-            components.assign("month", date.month() + 1);
+            date.setDate(1);
+            components.imply("day", date.getDate());
+            components.assign("year", date.getFullYear());
+            components.assign("month", date.getMonth() + 1);
         }
 
         // This year
         else if (unitWord.match(/jaar/i)) {
-            date = date.add(-date.date() + 1, "d");
-            date = date.add(-date.month(), "month");
-
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.assign("year", date.year());
+            date.setDate(1);
+            date.setMonth(0);
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.assign("year", date.getFullYear());
         }
 
-        return components;
+        return addImpliedTimeUnits(components, {
+            hour: 12,
+        });
     }
 }

--- a/src/locales/ru/constants.ts
+++ b/src/locales/ru/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const REGEX_PARTS = {
     leftBoundary: "([^\\p{L}\\p{N}_]|^)",
@@ -201,7 +201,7 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "тридцать первого": 31,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     сек: "second",
     секунда: "second",
     секунд: "second",
@@ -230,11 +230,11 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     часика: "hour",
     часике: "hour",
     часик: "hour",
-    день: "d",
-    дня: "d",
-    дней: "d",
-    суток: "d",
-    сутки: "d",
+    день: "day",
+    дня: "day",
+    дней: "day",
+    суток: "day",
+    сутки: "day",
     неделя: "week",
     неделе: "week",
     недели: "week",

--- a/src/locales/ru/parsers/RURelativeDateFormatParser.ts
+++ b/src/locales/ru/parsers/RURelativeDateFormatParser.ts
@@ -1,10 +1,9 @@
-import { REGEX_PARTS, TIME_UNIT_DICTIONARY } from "../constants";
+import { TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import dayjs from "dayjs";
-import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithLeftRightBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { addImpliedTimeUnits } from "../../../utils/timeunits";
 
 const MODIFIER_WORD_GROUP = 1;
 const RELATIVE_WORD_GROUP = 2;
@@ -34,34 +33,35 @@ export default class RURelativeDateFormatParser extends AbstractParserWithLeftRi
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.reference.instant);
+        let date = new Date(context.reference.instant.getTime());
 
         // This week
         if (timeunit.match(/week/i)) {
-            date = date.add(-date.get("d"), "d");
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.imply("year", date.year());
+            date.setDate(date.getDate() - date.getDay());
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.imply("year", date.getFullYear());
         }
 
         // This month
         else if (timeunit.match(/month/i)) {
-            date = date.add(-date.date() + 1, "d");
-            components.imply("day", date.date());
-            components.assign("year", date.year());
-            components.assign("month", date.month() + 1);
+            date.setDate(1);
+            components.imply("day", date.getDate());
+            components.assign("year", date.getFullYear());
+            components.assign("month", date.getMonth() + 1);
         }
 
         // This year
         else if (timeunit.match(/year/i)) {
-            date = date.add(-date.date() + 1, "d");
-            date = date.add(-date.month(), "month");
-
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.assign("year", date.year());
+            date.setDate(1);
+            date.setMonth(0);
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.assign("year", date.getFullYear());
         }
 
-        return components;
+        return addImpliedTimeUnits(components, {
+            hour: 12,
+        });
     }
 }

--- a/src/locales/sv/constants.ts
+++ b/src/locales/sv/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
     "söndag": 0,
@@ -132,7 +132,7 @@ export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
     "tusen": 1000,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     "sekund": "second",
     "sekunder": "second",
     "sek": "second",

--- a/src/locales/uk/constants.ts
+++ b/src/locales/uk/constants.ts
@@ -1,7 +1,7 @@
-import { OpUnitType, QUnitType } from "dayjs";
 import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
 import { findMostLikelyADYear } from "../../calculation/years";
 import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
 
 export const REGEX_PARTS = {
     leftBoundary: "([^\\p{L}\\p{N}_]|^)",
@@ -211,7 +211,7 @@ export const ORDINAL_WORD_DICTIONARY: { [word: string]: number } = {
     "тридцять першого": 31,
 };
 
-export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = {
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
     сек: "second",
     секунда: "second",
     секунд: "second",
@@ -240,12 +240,12 @@ export const TIME_UNIT_DICTIONARY: { [word: string]: OpUnitType | QUnitType } = 
     годинок: "hour",
     годинки: "hour",
     годинку: "hour",
-    день: "d",
-    дня: "d",
-    днів: "d",
-    дні: "d",
-    доба: "d",
-    добу: "d",
+    день: "day",
+    дня: "day",
+    днів: "day",
+    дні: "day",
+    доба: "day",
+    добу: "day",
     тиждень: "week",
     тижню: "week",
     тижня: "week",

--- a/src/locales/uk/parsers/UKRelativeDateFormatParser.ts
+++ b/src/locales/uk/parsers/UKRelativeDateFormatParser.ts
@@ -1,9 +1,9 @@
 import { TIME_UNIT_DICTIONARY } from "../constants";
 import { ParsingContext } from "../../../chrono";
 import { ParsingComponents } from "../../../results";
-import dayjs from "dayjs";
 import { matchAnyPattern } from "../../../utils/pattern";
 import { AbstractParserWithLeftRightBoundaryChecking } from "./AbstractParserWithWordBoundaryChecking";
+import { addImpliedTimeUnits } from "../../../utils/timeunits";
 
 const MODIFIER_WORD_GROUP = 1;
 const RELATIVE_WORD_GROUP = 2;
@@ -44,34 +44,35 @@ export default class UKRelativeDateFormatParser extends AbstractParserWithLeftRi
         }
 
         const components = context.createParsingComponents();
-        let date = dayjs(context.reference.instant);
+        let date = new Date(context.reference.instant.getTime());
 
         // This week
         if (timeunit.match(/week/i)) {
-            date = date.add(-date.get("d"), "d");
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.imply("year", date.year());
+            date.setDate(date.getDate() - date.getDay());
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.imply("year", date.getFullYear());
         }
 
         // This month
         else if (timeunit.match(/month/i)) {
-            date = date.add(-date.date() + 1, "d");
-            components.imply("day", date.date());
-            components.assign("year", date.year());
-            components.assign("month", date.month() + 1);
+            date.setDate(1);
+            components.imply("day", date.getDate());
+            components.assign("year", date.getFullYear());
+            components.assign("month", date.getMonth() + 1);
         }
 
         // This year
         else if (timeunit.match(/year/i)) {
-            date = date.add(-date.date() + 1, "d");
-            date = date.add(-date.month(), "month");
-
-            components.imply("day", date.date());
-            components.imply("month", date.month() + 1);
-            components.assign("year", date.year());
+            date.setDate(1);
+            date.setMonth(0);
+            components.imply("day", date.getDate());
+            components.imply("month", date.getMonth() + 1);
+            components.assign("year", date.getFullYear());
         }
 
-        return components;
+        return addImpliedTimeUnits(components, {
+            hour: 12,
+        });
     }
 }

--- a/src/locales/zh/hans/parsers/ZHHansCasualDateParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansCasualDateParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingComponents, ParsingResult } from "../../../../results";
@@ -27,33 +26,33 @@ export default class ZHHansCasualDateParser extends AbstractParserWithWordBounda
         const index = match.index;
         const result = context.createParsingResult(index, match[0]);
 
-        const refMoment = dayjs(context.refDate);
-        let startMoment = refMoment;
+        const refDate = context.refDate;
+        let date = new Date(refDate.getTime());
 
         if (match[NOW_GROUP]) {
-            result.start.imply("hour", refMoment.hour());
-            result.start.imply("minute", refMoment.minute());
-            result.start.imply("second", refMoment.second());
-            result.start.imply("millisecond", refMoment.millisecond());
+            result.start.imply("hour", refDate.getHours());
+            result.start.imply("minute", refDate.getMinutes());
+            result.start.imply("second", refDate.getSeconds());
+            result.start.imply("millisecond", refDate.getMilliseconds());
         } else if (match[DAY_GROUP_1]) {
             const day1 = match[DAY_GROUP_1];
             const time1 = match[TIME_GROUP_1];
 
             if (day1 == "明") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (refDate.getHours() > 1) {
+                    date.setDate(date.getDate() + 1);
                 }
             } else if (day1 == "昨") {
-                startMoment = startMoment.add(-1, "day");
+                date.setDate(date.getDate() - 1);
             } else if (day1 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                date.setDate(date.getDate() - 2);
             } else if (day1 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                date.setDate(date.getDate() - 3);
             } else if (day1 == "后") {
-                startMoment = startMoment.add(2, "day");
+                date.setDate(date.getDate() + 2);
             } else if (day1 == "大后") {
-                startMoment = startMoment.add(3, "day");
+                date.setDate(date.getDate() + 3);
             }
 
             if (time1 == "早") {
@@ -84,19 +83,19 @@ export default class ZHHansCasualDateParser extends AbstractParserWithWordBounda
 
             if (day3 == "明") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (refDate.getHours() > 1) {
+                    date.setDate(date.getDate() + 1);
                 }
             } else if (day3 == "昨") {
-                startMoment = startMoment.add(-1, "day");
+                date.setDate(date.getDate() - 1);
             } else if (day3 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                date.setDate(date.getDate() - 2);
             } else if (day3 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                date.setDate(date.getDate() - 3);
             } else if (day3 == "后") {
-                startMoment = startMoment.add(2, "day");
+                date.setDate(date.getDate() + 2);
             } else if (day3 == "大后") {
-                startMoment = startMoment.add(3, "day");
+                date.setDate(date.getDate() + 3);
             }
 
             const timeString3 = match[TIME_GROUP_3];
@@ -119,9 +118,9 @@ export default class ZHHansCasualDateParser extends AbstractParserWithWordBounda
             }
         }
 
-        result.start.assign("day", startMoment.date());
-        result.start.assign("month", startMoment.month() + 1);
-        result.start.assign("year", startMoment.year());
+        result.start.assign("day", date.getDate());
+        result.start.assign("month", date.getMonth() + 1);
+        result.start.assign("year", date.getFullYear());
 
         return result;
     }

--- a/src/locales/zh/hans/parsers/ZHHansDateParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansDateParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { NUMBER, zhStringToNumber, zhStringToYear } from "../constants";
@@ -44,7 +43,6 @@ export default class ZHHansDateParser extends AbstractParserWithWordBoundaryChec
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
-        const startMoment = dayjs(context.refDate);
         const result = context.createParsingResult(match.index, match[0]);
 
         //Month
@@ -58,7 +56,7 @@ export default class ZHHansDateParser extends AbstractParserWithWordBoundaryChec
             if (isNaN(day)) day = zhStringToNumber(match[DAY_GROUP]);
             result.start.assign("day", day);
         } else {
-            result.start.imply("day", startMoment.date());
+            result.start.imply("day", context.refDate.getDate());
         }
 
         //Year
@@ -67,7 +65,7 @@ export default class ZHHansDateParser extends AbstractParserWithWordBoundaryChec
             if (isNaN(year)) year = zhStringToYear(match[YEAR_GROUP]);
             result.start.assign("year", year);
         } else {
-            result.start.imply("year", startMoment.year());
+            result.start.imply("year", context.refDate.getFullYear());
         }
 
         return result;

--- a/src/locales/zh/hans/parsers/ZHHansDeadlineFormatParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansDeadlineFormatParser.ts
@@ -1,6 +1,6 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
+import { addDuration, Duration } from "../../../../calculation/duration";
 import { NUMBER, zhStringToNumber } from "../constants";
 
 const PATTERN = new RegExp(
@@ -41,41 +41,43 @@ export default class ZHHansDeadlineFormatParser extends AbstractParserWithWordBo
             }
         }
 
-        let date = dayjs(context.refDate);
+        const duration: Duration = {};
         const unit = match[UNIT_GROUP];
         const unitAbbr = unit[0];
 
         if (unitAbbr.match(/[日天星礼月年]/)) {
             if (unitAbbr == "日" || unitAbbr == "天") {
-                date = date.add(number, "d");
+                duration.day = number;
             } else if (unitAbbr == "星" || unitAbbr == "礼") {
-                date = date.add(number * 7, "d");
+                duration.week = number;
             } else if (unitAbbr == "月") {
-                date = date.add(number, "month");
+                duration.month = number;
             } else if (unitAbbr == "年") {
-                date = date.add(number, "year");
+                duration.year = number;
             }
 
-            result.start.assign("year", date.year());
-            result.start.assign("month", date.month() + 1);
-            result.start.assign("day", date.date());
+            const date = addDuration(context.refDate, duration);
+            result.start.assign("year", date.getFullYear());
+            result.start.assign("month", date.getMonth() + 1);
+            result.start.assign("day", date.getDate());
             return result;
         }
 
         if (unitAbbr == "秒") {
-            date = date.add(number, "second");
+            duration.second = number;
         } else if (unitAbbr == "分") {
-            date = date.add(number, "minute");
+            duration.minute = number;
         } else if (unitAbbr == "小" || unitAbbr == "钟") {
-            date = date.add(number, "hour");
+            duration.hour = number;
         }
 
-        result.start.imply("year", date.year());
-        result.start.imply("month", date.month() + 1);
-        result.start.imply("day", date.date());
-        result.start.assign("hour", date.hour());
-        result.start.assign("minute", date.minute());
-        result.start.assign("second", date.second());
+        const date = addDuration(context.refDate, duration);
+        result.start.imply("year", date.getFullYear());
+        result.start.imply("month", date.getMonth() + 1);
+        result.start.imply("day", date.getDate());
+        result.start.assign("hour", date.getHours());
+        result.start.assign("minute", date.getMinutes());
+        result.start.assign("second", date.getSeconds());
         return result;
     }
 }

--- a/src/locales/zh/hans/parsers/ZHHansRelationWeekdayParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansRelationWeekdayParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingResult } from "../../../../results";
@@ -31,37 +30,38 @@ export default class ZHHansRelationWeekdayParser extends AbstractParserWithWordB
             modifier = "this";
         }
 
-        let startMoment = dayjs(context.refDate);
+        const date = new Date(context.refDate.getTime());
         let startMomentFixed = false;
-        const refOffset = startMoment.day();
+        const refOffset = date.getDay();
 
         if (modifier == "last" || modifier == "past") {
-            startMoment = startMoment.day(offset - 7);
+            date.setDate(date.getDate() + (offset - 7 - refOffset));
             startMomentFixed = true;
         } else if (modifier == "next") {
-            startMoment = startMoment.day(offset + 7);
+            date.setDate(date.getDate() + (offset + 7 - refOffset));
             startMomentFixed = true;
         } else if (modifier == "this") {
-            startMoment = startMoment.day(offset);
+            date.setDate(date.getDate() + (offset - refOffset));
         } else {
-            if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-                startMoment = startMoment.day(offset - 7);
-            } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-                startMoment = startMoment.day(offset + 7);
-            } else {
-                startMoment = startMoment.day(offset);
+            let diff = offset - refOffset;
+            if (Math.abs(diff - 7) < Math.abs(diff)) {
+                diff -= 7;
             }
+            if (Math.abs(diff + 7) < Math.abs(diff)) {
+                diff += 7;
+            }
+            date.setDate(date.getDate() + diff);
         }
 
         result.start.assign("weekday", offset);
         if (startMomentFixed) {
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", date.getDate());
+            result.start.assign("month", date.getMonth() + 1);
+            result.start.assign("year", date.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", date.getDate());
+            result.start.imply("month", date.getMonth() + 1);
+            result.start.imply("year", date.getFullYear());
         }
 
         return result;

--- a/src/locales/zh/hans/parsers/ZHHansTimeExpressionParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansTimeExpressionParser.ts
@@ -1,6 +1,6 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
+import { addImpliedTimeUnits } from "../../../../utils/timeunits";
 import { NUMBER, zhStringToNumber } from "../constants";
 
 const FIRST_REG_PATTERN = new RegExp(
@@ -74,54 +74,53 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
             return null;
         }
 
-        const refMoment = dayjs(context.refDate);
         const result = context.createParsingResult(match.index, match[0]);
-        let startMoment = refMoment.clone();
+        const startMoment = new Date(context.refDate.getTime());
 
         // ----- Day
         if (match[DAY_GROUP_1]) {
             const day1 = match[DAY_GROUP_1];
             if (day1 == "明") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (context.refDate.getHours() > 1) {
+                    startMoment.setDate(startMoment.getDate() + 1);
                 }
             } else if (day1 == "昨") {
-                startMoment = startMoment.add(-1, "day");
+                startMoment.setDate(startMoment.getDate() - 1);
             } else if (day1 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                startMoment.setDate(startMoment.getDate() - 2);
             } else if (day1 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                startMoment.setDate(startMoment.getDate() - 3);
             } else if (day1 == "后") {
-                startMoment = startMoment.add(2, "day");
+                startMoment.setDate(startMoment.getDate() + 2);
             } else if (day1 == "大后") {
-                startMoment = startMoment.add(3, "day");
+                startMoment.setDate(startMoment.getDate() + 3);
             }
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", startMoment.getDate());
+            result.start.assign("month", startMoment.getMonth() + 1);
+            result.start.assign("year", startMoment.getFullYear());
         } else if (match[DAY_GROUP_3]) {
             const day3 = match[DAY_GROUP_3];
             if (day3 == "明") {
-                startMoment = startMoment.add(1, "day");
+                startMoment.setDate(startMoment.getDate() + 1);
             } else if (day3 == "昨") {
-                startMoment = startMoment.add(-1, "day");
+                startMoment.setDate(startMoment.getDate() - 1);
             } else if (day3 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                startMoment.setDate(startMoment.getDate() - 2);
             } else if (day3 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                startMoment.setDate(startMoment.getDate() - 3);
             } else if (day3 == "后") {
-                startMoment = startMoment.add(2, "day");
+                startMoment.setDate(startMoment.getDate() + 2);
             } else if (day3 == "大后") {
-                startMoment = startMoment.add(3, "day");
+                startMoment.setDate(startMoment.getDate() + 3);
             }
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", startMoment.getDate());
+            result.start.assign("month", startMoment.getMonth() + 1);
+            result.start.assign("year", startMoment.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", startMoment.getDate());
+            result.start.imply("month", startMoment.getMonth() + 1);
+            result.start.imply("year", startMoment.getFullYear());
         }
 
         let hour = 0;
@@ -233,8 +232,8 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
         //                  Extracting the 'to' chunk
         // ==============================================================
 
-        match = SECOND_REG_PATTERN.exec(context.text.substring(result.index + result.text.length));
-        if (!match) {
+        const secondMatch = SECOND_REG_PATTERN.exec(context.text.substring(result.index + result.text.length));
+        if (!secondMatch) {
             // Not accept number only result
             if (result.text.match(/^\d+$/)) {
                 return null;
@@ -242,53 +241,53 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
             return result;
         }
 
-        let endMoment = startMoment.clone();
+        const endMoment = new Date(startMoment.getTime());
         result.end = context.createParsingComponents();
 
         // ----- Day
-        if (match[DAY_GROUP_1]) {
-            const day1 = match[DAY_GROUP_1];
+        if (secondMatch[DAY_GROUP_1]) {
+            const day1 = secondMatch[DAY_GROUP_1];
             if (day1 == "明") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    endMoment = endMoment.add(1, "day");
+                if (context.refDate.getHours() > 1) {
+                    endMoment.setDate(endMoment.getDate() + 1);
                 }
             } else if (day1 == "昨") {
-                endMoment = endMoment.add(-1, "day");
+                endMoment.setDate(endMoment.getDate() - 1);
             } else if (day1 == "前") {
-                endMoment = endMoment.add(-2, "day");
+                endMoment.setDate(endMoment.getDate() - 2);
             } else if (day1 == "大前") {
-                endMoment = endMoment.add(-3, "day");
+                endMoment.setDate(endMoment.getDate() - 3);
             } else if (day1 == "后") {
-                endMoment = endMoment.add(2, "day");
+                endMoment.setDate(endMoment.getDate() + 2);
             } else if (day1 == "大后") {
-                endMoment = endMoment.add(3, "day");
+                endMoment.setDate(endMoment.getDate() + 3);
             }
-            result.end.assign("day", endMoment.date());
-            result.end.assign("month", endMoment.month() + 1);
-            result.end.assign("year", endMoment.year());
-        } else if (match[DAY_GROUP_3]) {
-            const day3 = match[DAY_GROUP_3];
+            result.end.assign("day", endMoment.getDate());
+            result.end.assign("month", endMoment.getMonth() + 1);
+            result.end.assign("year", endMoment.getFullYear());
+        } else if (secondMatch[DAY_GROUP_3]) {
+            const day3 = secondMatch[DAY_GROUP_3];
             if (day3 == "明") {
-                endMoment = endMoment.add(1, "day");
+                endMoment.setDate(endMoment.getDate() + 1);
             } else if (day3 == "昨") {
-                endMoment = endMoment.add(-1, "day");
+                endMoment.setDate(endMoment.getDate() - 1);
             } else if (day3 == "前") {
-                endMoment = endMoment.add(-2, "day");
+                endMoment.setDate(endMoment.getDate() - 2);
             } else if (day3 == "大前") {
-                endMoment = endMoment.add(-3, "day");
+                endMoment.setDate(endMoment.getDate() - 3);
             } else if (day3 == "后") {
-                endMoment = endMoment.add(2, "day");
+                endMoment.setDate(endMoment.getDate() + 2);
             } else if (day3 == "大后") {
-                endMoment = endMoment.add(3, "day");
+                endMoment.setDate(endMoment.getDate() + 3);
             }
-            result.end.assign("day", endMoment.date());
-            result.end.assign("month", endMoment.month() + 1);
-            result.end.assign("year", endMoment.year());
+            result.end.assign("day", endMoment.getDate());
+            result.end.assign("month", endMoment.getMonth() + 1);
+            result.end.assign("year", endMoment.getFullYear());
         } else {
-            result.end.imply("day", endMoment.date());
-            result.end.imply("month", endMoment.month() + 1);
-            result.end.imply("year", endMoment.year());
+            result.end.imply("day", endMoment.getDate());
+            result.end.imply("month", endMoment.getMonth() + 1);
+            result.end.imply("year", endMoment.getFullYear());
         }
 
         hour = 0;
@@ -296,31 +295,31 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
         meridiem = -1;
 
         // ----- Second
-        if (match[SECOND_GROUP]) {
-            let second = parseInt(match[SECOND_GROUP]);
+        if (secondMatch[SECOND_GROUP]) {
+            let second = parseInt(secondMatch[SECOND_GROUP]);
             if (isNaN(second)) {
-                second = zhStringToNumber(match[SECOND_GROUP]);
+                second = zhStringToNumber(secondMatch[SECOND_GROUP]);
             }
 
             if (second >= 60) return null;
             result.end.assign("second", second);
         }
 
-        hour = parseInt(match[HOUR_GROUP]);
+        hour = parseInt(secondMatch[HOUR_GROUP]);
         if (isNaN(hour)) {
-            hour = zhStringToNumber(match[HOUR_GROUP]);
+            hour = zhStringToNumber(secondMatch[HOUR_GROUP]);
         }
 
         // ----- Minutes
-        if (match[MINUTE_GROUP]) {
-            if (match[MINUTE_GROUP] == "半") {
+        if (secondMatch[MINUTE_GROUP]) {
+            if (secondMatch[MINUTE_GROUP] == "半") {
                 minute = 30;
-            } else if (match[MINUTE_GROUP] == "正" || match[MINUTE_GROUP] == "整") {
+            } else if (secondMatch[MINUTE_GROUP] == "正" || secondMatch[MINUTE_GROUP] == "整") {
                 minute = 0;
             } else {
-                minute = parseInt(match[MINUTE_GROUP]);
+                minute = parseInt(secondMatch[MINUTE_GROUP]);
                 if (isNaN(minute)) {
-                    minute = zhStringToNumber(match[MINUTE_GROUP]);
+                    minute = zhStringToNumber(secondMatch[MINUTE_GROUP]);
                 }
             }
         } else if (hour > 100) {
@@ -340,9 +339,9 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
         }
 
         // ----- AM & PM
-        if (match[AM_PM_HOUR_GROUP]) {
+        if (secondMatch[AM_PM_HOUR_GROUP]) {
             if (hour > 12) return null;
-            const ampm = match[AM_PM_HOUR_GROUP][0].toLowerCase();
+            const ampm = secondMatch[AM_PM_HOUR_GROUP][0].toLowerCase();
             if (ampm == "a") {
                 meridiem = 0;
                 if (hour == 12) hour = 0;
@@ -368,8 +367,8 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
                     }
                 }
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_1]) {
-            const zhAMPMString1 = match[ZH_AM_PM_HOUR_GROUP_1];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_1]) {
+            const zhAMPMString1 = secondMatch[ZH_AM_PM_HOUR_GROUP_1];
             const zhAMPM1 = zhAMPMString1[0];
             if (zhAMPM1 == "早") {
                 meridiem = 0;
@@ -378,8 +377,8 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
                 meridiem = 1;
                 if (hour != 12) hour += 12;
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_2]) {
-            const zhAMPMString2 = match[ZH_AM_PM_HOUR_GROUP_2];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_2]) {
+            const zhAMPMString2 = secondMatch[ZH_AM_PM_HOUR_GROUP_2];
             const zhAMPM2 = zhAMPMString2[0];
             if (zhAMPM2 == "上" || zhAMPM2 == "早" || zhAMPM2 == "凌") {
                 meridiem = 0;
@@ -388,8 +387,8 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
                 meridiem = 1;
                 if (hour != 12) hour += 12;
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_3]) {
-            const zhAMPMString3 = match[ZH_AM_PM_HOUR_GROUP_3];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_3]) {
+            const zhAMPMString3 = secondMatch[ZH_AM_PM_HOUR_GROUP_3];
             const zhAMPM3 = zhAMPMString3[0];
             if (zhAMPM3 == "上" || zhAMPM3 == "早" || zhAMPM3 == "凌") {
                 meridiem = 0;
@@ -400,7 +399,7 @@ export default class ZHHansTimeExpressionParser extends AbstractParserWithWordBo
             }
         }
 
-        result.text = result.text + match[0];
+        result.text = result.text + secondMatch[0];
         result.end.assign("hour", hour);
         result.end.assign("minute", minute);
         if (meridiem >= 0) {

--- a/src/locales/zh/hans/parsers/ZHHansWeekdayParser.ts
+++ b/src/locales/zh/hans/parsers/ZHHansWeekdayParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingResult } from "../../../../results";
@@ -18,27 +17,29 @@ export default class ZHHansWeekdayParser extends AbstractParserWithWordBoundaryC
         const offset = WEEKDAY_OFFSET[dayOfWeek];
         if (offset === undefined) return null;
 
-        let startMoment = dayjs(context.refDate);
+        const date = new Date(context.refDate.getTime());
         const startMomentFixed = false;
-        const refOffset = startMoment.day();
+        const refOffset = date.getDay();
 
-        if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-            startMoment = startMoment.day(offset - 7);
-        } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-            startMoment = startMoment.day(offset + 7);
-        } else {
-            startMoment = startMoment.day(offset);
+        let diff = offset - refOffset;
+        if (Math.abs(diff - 7) < Math.abs(diff)) {
+            diff -= 7;
         }
+        if (Math.abs(diff + 7) < Math.abs(diff)) {
+            diff += 7;
+        }
+
+        date.setDate(date.getDate() + diff);
 
         result.start.assign("weekday", offset);
         if (startMomentFixed) {
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", date.getDate());
+            result.start.assign("month", date.getMonth() + 1);
+            result.start.assign("year", date.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", date.getDate());
+            result.start.imply("month", date.getMonth() + 1);
+            result.start.imply("year", date.getFullYear());
         }
 
         return result;

--- a/src/locales/zh/hant/parsers/ZHHantCasualDateParser.ts
+++ b/src/locales/zh/hant/parsers/ZHHantCasualDateParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingComponents, ParsingResult } from "../../../../results";
@@ -27,33 +26,33 @@ export default class ZHHantCasualDateParser extends AbstractParserWithWordBounda
         const index = match.index;
         const result = context.createParsingResult(index, match[0]);
 
-        const refMoment = dayjs(context.refDate);
-        let startMoment = refMoment;
+        const refDate = context.refDate;
+        let date = new Date(refDate.getTime());
 
         if (match[NOW_GROUP]) {
-            result.start.imply("hour", refMoment.hour());
-            result.start.imply("minute", refMoment.minute());
-            result.start.imply("second", refMoment.second());
-            result.start.imply("millisecond", refMoment.millisecond());
+            result.start.imply("hour", refDate.getHours());
+            result.start.imply("minute", refDate.getMinutes());
+            result.start.imply("second", refDate.getSeconds());
+            result.start.imply("millisecond", refDate.getMilliseconds());
         } else if (match[DAY_GROUP_1]) {
             const day1 = match[DAY_GROUP_1];
             const time1 = match[TIME_GROUP_1];
 
             if (day1 == "明" || day1 == "聽") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (refDate.getHours() > 1) {
+                    date.setDate(date.getDate() + 1);
                 }
             } else if (day1 == "昨" || day1 == "尋" || day1 == "琴") {
-                startMoment = startMoment.add(-1, "day");
+                date.setDate(date.getDate() - 1);
             } else if (day1 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                date.setDate(date.getDate() - 2);
             } else if (day1 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                date.setDate(date.getDate() - 3);
             } else if (day1 == "後") {
-                startMoment = startMoment.add(2, "day");
+                date.setDate(date.getDate() + 2);
             } else if (day1 == "大後") {
-                startMoment = startMoment.add(3, "day");
+                date.setDate(date.getDate() + 3);
             }
 
             if (time1 == "早" || time1 == "朝") {
@@ -84,19 +83,19 @@ export default class ZHHantCasualDateParser extends AbstractParserWithWordBounda
 
             if (day3 == "明" || day3 == "聽") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (refDate.getHours() > 1) {
+                    date.setDate(date.getDate() + 1);
                 }
             } else if (day3 == "昨" || day3 == "尋" || day3 == "琴") {
-                startMoment = startMoment.add(-1, "day");
+                date.setDate(date.getDate() - 1);
             } else if (day3 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                date.setDate(date.getDate() - 2);
             } else if (day3 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                date.setDate(date.getDate() - 3);
             } else if (day3 == "後") {
-                startMoment = startMoment.add(2, "day");
+                date.setDate(date.getDate() + 2);
             } else if (day3 == "大後") {
-                startMoment = startMoment.add(3, "day");
+                date.setDate(date.getDate() + 3);
             }
 
             const timeString3 = match[TIME_GROUP_3];
@@ -119,9 +118,9 @@ export default class ZHHantCasualDateParser extends AbstractParserWithWordBounda
             }
         }
 
-        result.start.assign("day", startMoment.date());
-        result.start.assign("month", startMoment.month() + 1);
-        result.start.assign("year", startMoment.year());
+        result.start.assign("day", date.getDate());
+        result.start.assign("month", date.getMonth() + 1);
+        result.start.assign("year", date.getFullYear());
 
         return result;
     }

--- a/src/locales/zh/hant/parsers/ZHHantDateParser.ts
+++ b/src/locales/zh/hant/parsers/ZHHantDateParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { NUMBER, zhStringToNumber, zhStringToYear } from "../constants";
@@ -37,7 +36,6 @@ export default class ZHHantDateParser extends AbstractParserWithWordBoundaryChec
     }
 
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
-        const startMoment = dayjs(context.refDate);
         const result = context.createParsingResult(match.index, match[0]);
 
         //Month
@@ -51,7 +49,7 @@ export default class ZHHantDateParser extends AbstractParserWithWordBoundaryChec
             if (isNaN(day)) day = zhStringToNumber(match[DAY_GROUP]);
             result.start.assign("day", day);
         } else {
-            result.start.imply("day", startMoment.date());
+            result.start.imply("day", context.refDate.getDate());
         }
 
         //Year
@@ -60,7 +58,7 @@ export default class ZHHantDateParser extends AbstractParserWithWordBoundaryChec
             if (isNaN(year)) year = zhStringToYear(match[YEAR_GROUP]);
             result.start.assign("year", year);
         } else {
-            result.start.imply("year", startMoment.year());
+            result.start.imply("year", context.refDate.getFullYear());
         }
 
         return result;

--- a/src/locales/zh/hant/parsers/ZHHantRelationWeekdayParser.ts
+++ b/src/locales/zh/hant/parsers/ZHHantRelationWeekdayParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingResult } from "../../../../results";
@@ -31,37 +30,38 @@ export default class ZHHantRelationWeekdayParser extends AbstractParserWithWordB
             modifier = "this";
         }
 
-        let startMoment = dayjs(context.refDate);
+        const date = new Date(context.refDate.getTime());
         let startMomentFixed = false;
-        const refOffset = startMoment.day();
+        const refOffset = date.getDay();
 
         if (modifier == "last" || modifier == "past") {
-            startMoment = startMoment.day(offset - 7);
+            date.setDate(date.getDate() + (offset - 7 - refOffset));
             startMomentFixed = true;
         } else if (modifier == "next") {
-            startMoment = startMoment.day(offset + 7);
+            date.setDate(date.getDate() + (offset + 7 - refOffset));
             startMomentFixed = true;
         } else if (modifier == "this") {
-            startMoment = startMoment.day(offset);
+            date.setDate(date.getDate() + (offset - refOffset));
         } else {
-            if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-                startMoment = startMoment.day(offset - 7);
-            } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-                startMoment = startMoment.day(offset + 7);
-            } else {
-                startMoment = startMoment.day(offset);
+            let diff = offset - refOffset;
+            if (Math.abs(diff - 7) < Math.abs(diff)) {
+                diff -= 7;
             }
+            if (Math.abs(diff + 7) < Math.abs(diff)) {
+                diff += 7;
+            }
+            date.setDate(date.getDate() + diff);
         }
 
         result.start.assign("weekday", offset);
         if (startMomentFixed) {
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", date.getDate());
+            result.start.assign("month", date.getMonth() + 1);
+            result.start.assign("year", date.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", date.getDate());
+            result.start.imply("month", date.getMonth() + 1);
+            result.start.imply("year", date.getFullYear());
         }
 
         return result;

--- a/src/locales/zh/hant/parsers/ZHHantTimeExpressionParser.ts
+++ b/src/locales/zh/hant/parsers/ZHHantTimeExpressionParser.ts
@@ -1,6 +1,6 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
+import { addImpliedTimeUnits } from "../../../../utils/timeunits";
 import { NUMBER, zhStringToNumber } from "../constants";
 
 const FIRST_REG_PATTERN = new RegExp(
@@ -74,54 +74,53 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
             return null;
         }
 
-        const refMoment = dayjs(context.refDate);
         const result = context.createParsingResult(match.index, match[0]);
-        let startMoment = refMoment.clone();
+        const startMoment = new Date(context.refDate.getTime());
 
         // ----- Day
         if (match[DAY_GROUP_1]) {
-            var day1 = match[DAY_GROUP_1];
+            const day1 = match[DAY_GROUP_1];
             if (day1 == "明" || day1 == "聽") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    startMoment = startMoment.add(1, "day");
+                if (context.refDate.getHours() > 1) {
+                    startMoment.setDate(startMoment.getDate() + 1);
                 }
             } else if (day1 == "昨" || day1 == "尋" || day1 == "琴") {
-                startMoment = startMoment.add(-1, "day");
+                startMoment.setDate(startMoment.getDate() - 1);
             } else if (day1 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                startMoment.setDate(startMoment.getDate() - 2);
             } else if (day1 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                startMoment.setDate(startMoment.getDate() - 3);
             } else if (day1 == "後") {
-                startMoment = startMoment.add(2, "day");
+                startMoment.setDate(startMoment.getDate() + 2);
             } else if (day1 == "大後") {
-                startMoment = startMoment.add(3, "day");
+                startMoment.setDate(startMoment.getDate() + 3);
             }
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", startMoment.getDate());
+            result.start.assign("month", startMoment.getMonth() + 1);
+            result.start.assign("year", startMoment.getFullYear());
         } else if (match[DAY_GROUP_3]) {
-            var day3 = match[DAY_GROUP_3];
+            const day3 = match[DAY_GROUP_3];
             if (day3 == "明" || day3 == "聽") {
-                startMoment = startMoment.add(1, "day");
+                startMoment.setDate(startMoment.getDate() + 1);
             } else if (day3 == "昨" || day3 == "尋" || day3 == "琴") {
-                startMoment = startMoment.add(-1, "day");
+                startMoment.setDate(startMoment.getDate() - 1);
             } else if (day3 == "前") {
-                startMoment = startMoment.add(-2, "day");
+                startMoment.setDate(startMoment.getDate() - 2);
             } else if (day3 == "大前") {
-                startMoment = startMoment.add(-3, "day");
+                startMoment.setDate(startMoment.getDate() - 3);
             } else if (day3 == "後") {
-                startMoment = startMoment.add(2, "day");
+                startMoment.setDate(startMoment.getDate() + 2);
             } else if (day3 == "大後") {
-                startMoment = startMoment.add(3, "day");
+                startMoment.setDate(startMoment.getDate() + 3);
             }
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", startMoment.getDate());
+            result.start.assign("month", startMoment.getMonth() + 1);
+            result.start.assign("year", startMoment.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", startMoment.getDate());
+            result.start.imply("month", startMoment.getMonth() + 1);
+            result.start.imply("year", startMoment.getFullYear());
         }
 
         let hour = 0;
@@ -233,8 +232,8 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
         //                  Extracting the 'to' chunk
         // ==============================================================
 
-        match = SECOND_REG_PATTERN.exec(context.text.substring(result.index + result.text.length));
-        if (!match) {
+        const secondMatch = SECOND_REG_PATTERN.exec(context.text.substring(result.index + result.text.length));
+        if (!secondMatch) {
             // Not accept number only result
             if (result.text.match(/^\d+$/)) {
                 return null;
@@ -242,53 +241,53 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
             return result;
         }
 
-        let endMoment = startMoment.clone();
+        const endMoment = new Date(startMoment.getTime());
         result.end = context.createParsingComponents();
 
         // ----- Day
-        if (match[DAY_GROUP_1]) {
-            var day1 = match[DAY_GROUP_1];
+        if (secondMatch[DAY_GROUP_1]) {
+            const day1 = secondMatch[DAY_GROUP_1];
             if (day1 == "明" || day1 == "聽") {
                 // Check not "Tomorrow" on late night
-                if (refMoment.hour() > 1) {
-                    endMoment = endMoment.add(1, "day");
+                if (context.refDate.getHours() > 1) {
+                    endMoment.setDate(endMoment.getDate() + 1);
                 }
             } else if (day1 == "昨" || day1 == "尋" || day1 == "琴") {
-                endMoment = endMoment.add(-1, "day");
+                endMoment.setDate(endMoment.getDate() - 1);
             } else if (day1 == "前") {
-                endMoment = endMoment.add(-2, "day");
+                endMoment.setDate(endMoment.getDate() - 2);
             } else if (day1 == "大前") {
-                endMoment = endMoment.add(-3, "day");
+                endMoment.setDate(endMoment.getDate() - 3);
             } else if (day1 == "後") {
-                endMoment = endMoment.add(2, "day");
+                endMoment.setDate(endMoment.getDate() + 2);
             } else if (day1 == "大後") {
-                endMoment = endMoment.add(3, "day");
+                endMoment.setDate(endMoment.getDate() + 3);
             }
-            result.end.assign("day", endMoment.date());
-            result.end.assign("month", endMoment.month() + 1);
-            result.end.assign("year", endMoment.year());
-        } else if (match[DAY_GROUP_3]) {
-            var day3 = match[DAY_GROUP_3];
+            result.end.assign("day", endMoment.getDate());
+            result.end.assign("month", endMoment.getMonth() + 1);
+            result.end.assign("year", endMoment.getFullYear());
+        } else if (secondMatch[DAY_GROUP_3]) {
+            const day3 = secondMatch[DAY_GROUP_3];
             if (day3 == "明" || day3 == "聽") {
-                endMoment = endMoment.add(1, "day");
+                endMoment.setDate(endMoment.getDate() + 1);
             } else if (day3 == "昨" || day3 == "尋" || day3 == "琴") {
-                endMoment = endMoment.add(-1, "day");
+                endMoment.setDate(endMoment.getDate() - 1);
             } else if (day3 == "前") {
-                endMoment = endMoment.add(-2, "day");
+                endMoment.setDate(endMoment.getDate() - 2);
             } else if (day3 == "大前") {
-                endMoment = endMoment.add(-3, "day");
+                endMoment.setDate(endMoment.getDate() - 3);
             } else if (day3 == "後") {
-                endMoment = endMoment.add(2, "day");
+                endMoment.setDate(endMoment.getDate() + 2);
             } else if (day3 == "大後") {
-                endMoment = endMoment.add(3, "day");
+                endMoment.setDate(endMoment.getDate() + 3);
             }
-            result.end.assign("day", endMoment.date());
-            result.end.assign("month", endMoment.month() + 1);
-            result.end.assign("year", endMoment.year());
+            result.end.assign("day", endMoment.getDate());
+            result.end.assign("month", endMoment.getMonth() + 1);
+            result.end.assign("year", endMoment.getFullYear());
         } else {
-            result.end.imply("day", endMoment.date());
-            result.end.imply("month", endMoment.month() + 1);
-            result.end.imply("year", endMoment.year());
+            result.end.imply("day", endMoment.getDate());
+            result.end.imply("month", endMoment.getMonth() + 1);
+            result.end.imply("year", endMoment.getFullYear());
         }
 
         hour = 0;
@@ -296,31 +295,31 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
         meridiem = -1;
 
         // ----- Second
-        if (match[SECOND_GROUP]) {
-            var second = parseInt(match[SECOND_GROUP]);
+        if (secondMatch[SECOND_GROUP]) {
+            let second = parseInt(secondMatch[SECOND_GROUP]);
             if (isNaN(second)) {
-                second = zhStringToNumber(match[SECOND_GROUP]);
+                second = zhStringToNumber(secondMatch[SECOND_GROUP]);
             }
 
             if (second >= 60) return null;
             result.end.assign("second", second);
         }
 
-        hour = parseInt(match[HOUR_GROUP]);
+        hour = parseInt(secondMatch[HOUR_GROUP]);
         if (isNaN(hour)) {
-            hour = zhStringToNumber(match[HOUR_GROUP]);
+            hour = zhStringToNumber(secondMatch[HOUR_GROUP]);
         }
 
         // ----- Minutes
-        if (match[MINUTE_GROUP]) {
-            if (match[MINUTE_GROUP] == "半") {
+        if (secondMatch[MINUTE_GROUP]) {
+            if (secondMatch[MINUTE_GROUP] == "半") {
                 minute = 30;
-            } else if (match[MINUTE_GROUP] == "正" || match[MINUTE_GROUP] == "整") {
+            } else if (secondMatch[MINUTE_GROUP] == "正" || secondMatch[MINUTE_GROUP] == "整") {
                 minute = 0;
             } else {
-                minute = parseInt(match[MINUTE_GROUP]);
+                minute = parseInt(secondMatch[MINUTE_GROUP]);
                 if (isNaN(minute)) {
-                    minute = zhStringToNumber(match[MINUTE_GROUP]);
+                    minute = zhStringToNumber(secondMatch[MINUTE_GROUP]);
                 }
             }
         } else if (hour > 100) {
@@ -340,9 +339,9 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
         }
 
         // ----- AM & PM
-        if (match[AM_PM_HOUR_GROUP]) {
+        if (secondMatch[AM_PM_HOUR_GROUP]) {
             if (hour > 12) return null;
-            var ampm = match[AM_PM_HOUR_GROUP][0].toLowerCase();
+            var ampm = secondMatch[AM_PM_HOUR_GROUP][0].toLowerCase();
             if (ampm == "a") {
                 meridiem = 0;
                 if (hour == 12) hour = 0;
@@ -368,8 +367,8 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
                     }
                 }
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_1]) {
-            var zhAMPMString1 = match[ZH_AM_PM_HOUR_GROUP_1];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_1]) {
+            const zhAMPMString1 = secondMatch[ZH_AM_PM_HOUR_GROUP_1];
             var zhAMPM1 = zhAMPMString1[0];
             if (zhAMPM1 == "朝" || zhAMPM1 == "早") {
                 meridiem = 0;
@@ -378,8 +377,8 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
                 meridiem = 1;
                 if (hour != 12) hour += 12;
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_2]) {
-            var zhAMPMString2 = match[ZH_AM_PM_HOUR_GROUP_2];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_2]) {
+            const zhAMPMString2 = secondMatch[ZH_AM_PM_HOUR_GROUP_2];
             var zhAMPM2 = zhAMPMString2[0];
             if (zhAMPM2 == "上" || zhAMPM2 == "朝" || zhAMPM2 == "早" || zhAMPM2 == "凌") {
                 meridiem = 0;
@@ -388,8 +387,8 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
                 meridiem = 1;
                 if (hour != 12) hour += 12;
             }
-        } else if (match[ZH_AM_PM_HOUR_GROUP_3]) {
-            var zhAMPMString3 = match[ZH_AM_PM_HOUR_GROUP_3];
+        } else if (secondMatch[ZH_AM_PM_HOUR_GROUP_3]) {
+            const zhAMPMString3 = secondMatch[ZH_AM_PM_HOUR_GROUP_3];
             var zhAMPM3 = zhAMPMString3[0];
             if (zhAMPM3 == "上" || zhAMPM3 == "朝" || zhAMPM3 == "早" || zhAMPM3 == "凌") {
                 meridiem = 0;
@@ -400,7 +399,7 @@ export default class ZHHantTimeExpressionParser extends AbstractParserWithWordBo
             }
         }
 
-        result.text = result.text + match[0];
+        result.text = result.text + secondMatch[0];
         result.end.assign("hour", hour);
         result.end.assign("minute", minute);
         if (meridiem >= 0) {

--- a/src/locales/zh/hant/parsers/ZHHantWeekdayParser.ts
+++ b/src/locales/zh/hant/parsers/ZHHantWeekdayParser.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { ParsingContext } from "../../../../chrono";
 import { AbstractParserWithWordBoundaryChecking } from "../../../../common/parsers/AbstractParserWithWordBoundary";
 import { ParsingResult } from "../../../../results";
@@ -18,27 +17,29 @@ export default class ZHHantWeekdayParser extends AbstractParserWithWordBoundaryC
         const offset = WEEKDAY_OFFSET[dayOfWeek];
         if (offset === undefined) return null;
 
-        let startMoment = dayjs(context.refDate);
+        const date = new Date(context.refDate.getTime());
         const startMomentFixed = false;
-        const refOffset = startMoment.day();
+        const refOffset = date.getDay();
 
-        if (Math.abs(offset - 7 - refOffset) < Math.abs(offset - refOffset)) {
-            startMoment = startMoment.day(offset - 7);
-        } else if (Math.abs(offset + 7 - refOffset) < Math.abs(offset - refOffset)) {
-            startMoment = startMoment.day(offset + 7);
-        } else {
-            startMoment = startMoment.day(offset);
+        let diff = offset - refOffset;
+        if (Math.abs(diff - 7) < Math.abs(diff)) {
+            diff -= 7;
         }
+        if (Math.abs(diff + 7) < Math.abs(diff)) {
+            diff += 7;
+        }
+
+        date.setDate(date.getDate() + diff);
 
         result.start.assign("weekday", offset);
         if (startMomentFixed) {
-            result.start.assign("day", startMoment.date());
-            result.start.assign("month", startMoment.month() + 1);
-            result.start.assign("year", startMoment.year());
+            result.start.assign("day", date.getDate());
+            result.start.assign("month", date.getMonth() + 1);
+            result.start.assign("year", date.getFullYear());
         } else {
-            result.start.imply("day", startMoment.date());
-            result.start.imply("month", startMoment.month() + 1);
-            result.start.imply("year", startMoment.year());
+            result.start.imply("day", date.getDate());
+            result.start.imply("month", date.getMonth() + 1);
+            result.start.imply("year", date.getFullYear());
         }
 
         return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export type Component =
     | "meridiem"
     | "timezoneOffset";
 
-export type Timeunit = "year" | "month" | "week" | "day" | "hour" | "minute" | "second" | "millisecond";
+export type Timeunit = "year" | "month" | "week" | "day" | "hour" | "minute" | "second" | "millisecond" | "quarter";
 
 export enum Meridiem {
     AM = 0,

--- a/src/utils/timeunits.ts
+++ b/src/utils/timeunits.ts
@@ -1,0 +1,25 @@
+import { ParsingComponents } from "../results";
+import { Timeunit } from "../types";
+
+/**
+ * Returns a new ParsingComponents object with the given time units set as "implied" components.
+ *
+ * @param components
+ * @param timeUnits
+ */
+export function addImpliedTimeUnits(
+    components: ParsingComponents,
+    timeUnits: { [c in Timeunit]?: number }
+): ParsingComponents {
+    const newComponents = components.clone();
+    for (const key in timeUnits) {
+        if (key === "week" || key === "quarter") {
+            continue;
+        }
+        if (newComponents.isCertain(key as any)) {
+            continue;
+        }
+        newComponents.imply(key as any, timeUnits[key as Timeunit]);
+    }
+    return newComponents;
+}


### PR DESCRIPTION
This commit removes all usages of the `dayjs` library from the `src/locales` directory, replacing its functionality with native JavaScript `Date` objects and the project's existing `calculation/duration` module.

The changes include:
- Removing `dayjs` imports from all files in `src/locales`.
- Replacing `dayjs()` instantiations with `new Date()`.
- Replacing `dayjs` methods with their native `Date` equivalents or with new custom utility functions.
- Updating type definitions in `constants.ts` files to use a custom `Timeunit` type.
- Creating a new utility function `addImpliedTimeUnits` to handle a common pattern of date manipulation.
- Updating `package.json` and `package-lock.json` to remove dependencies that were only required by `dayjs`-related test utilities.