### PR TITLE
feat(test): Add more tests for zh/hans locale

### DIFF
--- a/test/zh/hans/zh_hans_deadline.test.ts
+++ b/test/zh/hans/zh_hans_deadline.test.ts
@@ -134,3 +134,42 @@ test("Test - Single Expression", function () {
         expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
     });
 });
+
+test("Test - Untested units", function () {
+    testSingleCase(chrono.zh.hans, "5秒钟后", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("5秒钟后");
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 10, 12, 14, 5);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+
+    testSingleCase(chrono.zh.hans, "2小时后", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("2小时后");
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 10, 14, 14);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+
+    testSingleCase(chrono.zh.hans, "3天后", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("3天后");
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 13, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+
+    testSingleCase(chrono.zh.hans, "2星期后", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("2星期后");
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 24, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+});
+
+test("Test - Untested suffix", function () {
+    testSingleCase(chrono.zh.hans, "5分钟过后", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("5分钟过后");
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 10, 12, 19);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+});

--- a/test/zh/hans/zh_hans_time_exp.test.ts
+++ b/test/zh/hans/zh_hans_time_exp.test.ts
@@ -248,3 +248,15 @@ test("Test - Random date + time expression", function () {
         expect(result.end.get("day")).toBe(11);
     });
 });
+
+test("Test - YYYY-MM-DD HH:mm:ss format", function () {
+    testSingleCase(chrono.zh.hans, "2023-10-26 10:30:00", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("2023-10-26 10:30:00");
+        expect(result.start.get("year")).toBe(2023);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(26);
+        expect(result.start.get("hour")).toBe(10);
+        expect(result.start.get("minute")).toBe(30);
+        expect(result.start.get("second")).toBe(0);
+    });
+});

--- a/test/zh/hans/zh_hans_weekday.test.ts
+++ b/test/zh/hans/zh_hans_weekday.test.ts
@@ -109,6 +109,67 @@ test("Test - Single Expression", function () {
     });
 });
 
+test("Test - 'this' week", function () {
+    testSingleCase(chrono.zh.hans, "我这个星期一要打游戏", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(1);
+        expect(result.text).toBe("这个星期一");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 6, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+});
+
+test("Test - Range with different separators", function () {
+    const text = "星期六至星期一";
+    testSingleCase(chrono.zh.hans, text, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+
+    const text2 = "星期六到星期一";
+    testSingleCase(chrono.zh.hans, text2, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text2);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+
+    const text3 = "星期六~星期一";
+    testSingleCase(chrono.zh.hans, text3, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text3);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+
+    const text4 = "星期六～星期一";
+    testSingleCase(chrono.zh.hans, text4, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text4);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+
+    const text5 = "星期六－星期一";
+    testSingleCase(chrono.zh.hans, text5, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text5);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+
+    const text6 = "星期六ー星期一";
+    testSingleCase(chrono.zh.hans, text6, new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
+        expect(result.text).toBe(text6);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.end.get("day")).toBe(5);
+    });
+});
+
 test("Test - forward dates only option", function () {
     testSingleCase(chrono.zh.hans, "星期六-星期一", new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
         expect(result.index).toBe(0);


### PR DESCRIPTION
This commit increases the test coverage for the `src/locales/zh/hans/` directory by adding more tests to the corresponding test files in `test/zh/hans/`.

The new tests cover various previously untested scenarios, such as:
- Different time units (`秒钟`, `小时`, `天`, `星期`)
- The `过后` suffix
- The `YYYY-MM-DD HH:mm:ss` date format
- Different weekday range separators (`至`, `到`, `~`, `～`, `－`, `ー`)
- The "this week" (`这个星期`) relative date expression