### PR TITLE
feat(sv): Add SVTimeUnitCasualRelativeFormatParser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "^3.5.3",
         "rimraf": "^6.0.1",
         "run-script-os": "^1.1.6",
-        "ts-jest": "^29.4.1",
+        "ts-jest": "^29.3.4",
         "tsc-esm-fix": "^3.1.2",
         "typedoc": "^0.28.4",
         "typescript": "~5.8.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,9 @@ import * as zh from "./locales/zh";
 import * as ru from "./locales/ru";
 import * as es from "./locales/es";
 import * as uk from "./locales/uk";
+import * as sv from "./locales/sv";
 
-export { de, fr, ja, pt, nl, zh, ru, es, uk };
+export { de, fr, ja, pt, nl, zh, ru, es, uk, sv };
 
 /**
  * A shortcut for {@link en | chrono.en.strict}

--- a/src/locales/sv/constants.ts
+++ b/src/locales/sv/constants.ts
@@ -133,24 +133,41 @@ export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
 };
 
 export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
+    "sek": "second",
     "sekund": "second",
     "sekunder": "second",
-    "sek": "second",
+    "min": "minute",
     "minut": "minute",
     "minuter": "minute",
-    "min": "minute",
+    "tim": "hour",
     "timme": "hour",
     "timmar": "hour",
-    "tim": "hour",
+    "dag": "day",
+    "dagar": "day",
+    "vecka": "week",
+    "veckor": "week",
+    "mån": "month",
+    "månad": "month",
+    "månader": "month",
+    "år": "year",
+    "kvartаl": "quarter",
+    "kvartal": "quarter",
+};
+
+export const TIME_UNIT_NO_ABBR_DICTIONARY: { [word: string]: Timeunit } = {
+    "sekund": "second",
+    "sekunder": "second",
+    "minut": "minute",
+    "minuter": "minute",
+    "timme": "hour",
+    "timmar": "hour",
     "dag": "day",
     "dagar": "day",
     "vecka": "week",
     "veckor": "week",
     "månad": "month",
     "månader": "month",
-    "mån": "month",
     "år": "year",
-    "kvartаl": "quarter",
     "kvartal": "quarter",
 };
 
@@ -179,7 +196,12 @@ export const TIME_UNIT_PATTERN = `(?:${matchAnyPattern(TIME_UNIT_DICTIONARY)})`;
 const SINGLE_TIME_UNIT_PATTERN = `(${NUMBER_PATTERN})\\s{0,5}(${matchAnyPattern(TIME_UNIT_DICTIONARY)})\\s{0,5}`;
 const SINGLE_TIME_UNIT_REGEX = new RegExp(SINGLE_TIME_UNIT_PATTERN, "i");
 
+const SINGLE_TIME_UNIT_NO_ABBR_PATTERN = `(${NUMBER_PATTERN})\\s{0,5}(${matchAnyPattern(
+    TIME_UNIT_NO_ABBR_DICTIONARY
+)})\\s{0,5}`;
+
 export const TIME_UNITS_PATTERN = repeatedTimeunitPattern("", SINGLE_TIME_UNIT_PATTERN);
+export const TIME_UNITS_NO_ABBR_PATTERN = repeatedTimeunitPattern("", SINGLE_TIME_UNIT_NO_ABBR_PATTERN);
 
 export function parseNumberPattern(match: string): number {
     const num = match.toLowerCase();

--- a/src/locales/sv/index.ts
+++ b/src/locales/sv/index.ts
@@ -6,6 +6,7 @@ import SlashDateFormatParser from "../../common/parsers/SlashDateFormatParser";
 import ISOFormatParser from "../../common/parsers/ISOFormatParser";
 import SVWeekdayParser from "./parsers/SVWeekdayParser";
 import SVMonthNameLittleEndianParser from "./parsers/SVMonthNameLittleEndianParser";
+import SVTimeUnitCasualRelativeFormatParser from "./parsers/SVTimeUnitCasualRelativeFormatParser";
 import SVCasualDateParser from "./parsers/SVCasualDateParser";
 
 export { Chrono, Parser, Refiner, ParsingResult, ParsingComponents, ReferenceWithTimezone };
@@ -37,6 +38,7 @@ export function createConfiguration(strictMode = true, littleEndian = true): Con
                 new SlashDateFormatParser(littleEndian),
                 new SVMonthNameLittleEndianParser(),
                 new SVWeekdayParser(),
+                new SVTimeUnitCasualRelativeFormatParser(),
             ],
             refiners: [],
         },

--- a/src/locales/sv/parsers/SVTimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/sv/parsers/SVTimeUnitCasualRelativeFormatParser.ts
@@ -1,0 +1,42 @@
+import { TIME_UNITS_PATTERN, parseDuration, TIME_UNITS_NO_ABBR_PATTERN } from "../constants";
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { reverseDuration } from "../../../calculation/duration";
+
+const PATTERN = new RegExp(
+    `(denna|den här|förra|passerade|nästa|kommande|efter|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
+    "i"
+);
+const PATTERN_NO_ABBR = new RegExp(
+    `(denna|den här|förra|passerade|nästa|kommande|efter|\\+|-)\\s*(${TIME_UNITS_NO_ABBR_PATTERN})(?=\\W|$)`,
+    "i"
+);
+
+export default class SVTimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
+    constructor(private allowAbbreviations: boolean = true) {
+        super();
+    }
+
+    innerPattern(): RegExp {
+        return this.allowAbbreviations ? PATTERN : PATTERN_NO_ABBR;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray) {
+        const prefix = match[1].toLowerCase();
+        let duration = parseDuration(match[2]);
+        if (!duration) {
+            return null;
+        }
+
+        switch (prefix) {
+            case "förra":
+            case "passerade":
+            case "-":
+                duration = reverseDuration(duration);
+                break;
+        }
+
+        return ParsingComponents.createRelativeFromReference(context.reference, duration);
+    }
+}

--- a/test/sv/sv_time_units_casual_relative.test.ts
+++ b/test/sv/sv_time_units_casual_relative.test.ts
@@ -1,0 +1,143 @@
+import * as chrono from "../../src";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+import SVTimeUnitCasualRelativeFormatParser from "../../src/locales/sv/parsers/SVTimeUnitCasualRelativeFormatParser";
+
+test("Test - Positive time units", () => {
+    testSingleCase(chrono.sv, "nästa 2 veckor", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono.sv, "nästa 2 dagar", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "nästa två år", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2018);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "nästa 2 veckor 3 dagar", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(18);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "efter ett år", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2017);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "efter en timme", new Date(2016, 10 - 1, 1, 15), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(16);
+    });
+});
+
+test("Test - Negative time units", () => {
+    testSingleCase(chrono.sv, "förra 2 veckor", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(17);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "förra två veckor", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(17);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "passerade 2 dagar", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(29);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.sv, "+2 månader, 5 dagar", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("hour")).toBe(12);
+    });
+});
+
+test("Test - Plus '+' sign", () => {
+    testSingleCase(chrono.sv.casual, "+15 minuter", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(29);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 29));
+    });
+
+    testSingleCase(chrono.sv.casual, "+15min", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(29);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 29));
+    });
+
+    testSingleCase(chrono.sv.casual, "+1 dag 2 timmar", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(14);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 11, 14, 14));
+    });
+
+    testSingleCase(chrono.sv.casual, "+1min", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 15));
+    });
+});
+
+test("Test - Minus '-' sign", () => {
+    testSingleCase(chrono.sv.casual, "-3år", new Date(2015, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(14);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 14));
+    });
+
+    testSingleCase(chrono.sv, "-2tim5min", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(9);
+        expect(result.start.get("minute")).toBe(55);
+    });
+});


### PR DESCRIPTION
Adds a new parser for Swedish (sv) that handles casual relative time formats, such as 'nästa 2 veckor' (next 2 weeks).

Includes:
- `src/locales/sv/parsers/SVTimeUnitCasualRelativeFormatParser.ts`: The new parser.
- `test/sv/sv_time_units_casual_relative.test.ts`: Tests for the new parser.
- Updates to `src/locales/sv/constants.ts` to support time unit abbreviations.
- Updates to `src/locales/sv/index.ts` and `src/index.ts` to include the new parser.