### PR TITLE
feat(test): Add tests for it locale

### DIFF
--- a/test/it/it_casual.test.ts
+++ b/test/it/it_casual.test.ts
@@ -1,0 +1,45 @@
+import * as chrono from "../../src/";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", () => {
+  testSingleCase(chrono.it.casual, "La scadenza è ora", new Date(2012, 7, 10, 8, 9, 10, 11), (result) => {
+    expect(result.index).toBe(14);
+    expect(result.text).toBe("ora");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(10);
+    expect(result.start.get("hour")).toBe(8);
+    expect(result.start.get("minute")).toBe(9);
+    expect(result.start.get("second")).toBe(10);
+    expect(result.start.get("millisecond")).toBe(11);
+
+    expect(result.start).toBeDate(new Date(2012, 7, 10, 8, 9, 10, 11));
+  });
+
+  testSingleCase(chrono.it.casual, "La scadenza è oggi", new Date(2012, 7, 10, 14, 12), (result) => {
+    expect(result.index).toBe(14);
+    expect(result.text).toBe("oggi");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(10);
+
+    expect(result.start).toBeDate(new Date(2012, 7, 10, 14, 12));
+  });
+
+  testSingleCase(chrono.it.casual, "La scadenza è domani", new Date(2012, 7, 10, 17, 10), (result) => {
+    expect(result.index).toBe(14);
+    expect(result.text).toBe("domani");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(11);
+
+    expect(result.start).toBeDate(new Date(2012, 7, 11, 17, 10));
+  });
+
+});

--- a/test/it/it_month_name_little_endian.test.ts
+++ b/test/it/it_month_name_little_endian.test.ts
@@ -1,0 +1,28 @@
+import * as chrono from "../../src/";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+
+test("Test - Single expression", () => {
+  testSingleCase(chrono.it, "10 Agosto 2012", new Date(2012, 7, 10), (result) => {
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(10);
+
+    expect(result.index).toBe(0);
+    expect(result.text).toBe("10 Agosto 2012");
+
+    expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+  });
+
+  testSingleCase(chrono.it, "La scadenza è il 10 Agosto", new Date(2012, 7, 10), (result) => {
+    expect(result.index).toBe(17);
+    expect(result.text).toBe("10 Agosto");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(10);
+
+    expect(result.start).toBeDate(new Date(2012, 8 - 1, 10, 12));
+  });
+});

--- a/test/it/it_weekday.test.ts
+++ b/test/it/it_weekday.test.ts
@@ -1,0 +1,37 @@
+import * as chrono from "../../src/";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", function () {
+  testSingleCase(chrono.it, "Lunedì", new Date(2012, 7, 9), (result) => {
+    expect(result.index).toBe(0);
+    expect(result.text).toBe("Lunedì");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(6);
+    expect(result.start.get("weekday")).toBe(1);
+  });
+
+  testSingleCase(chrono.it, "Giovedì", new Date(2012, 7, 9), (result) => {
+    expect(result.index).toBe(0);
+    expect(result.text).toBe("Giovedì");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(9);
+    expect(result.start.get("weekday")).toBe(4);
+  });
+
+  testSingleCase(chrono.it, "Domenica", new Date(2012, 7, 9), (result) => {
+    expect(result.index).toBe(0);
+    expect(result.text).toBe("Domenica");
+
+    expect(result.start).not.toBeNull();
+    expect(result.start.get("year")).toBe(2012);
+    expect(result.start.get("month")).toBe(8);
+    expect(result.start.get("day")).toBe(12);
+    expect(result.start.get("weekday")).toBe(0);
+  });
+});


### PR DESCRIPTION
This commit introduces tests for the Italian (`it`) locale. Following the existing test structure, three new test files have been added:
- `test/it/it_casual.test.ts`: For casual date expressions.
- `test/it/it_weekday.test.ts`: For weekday expressions.
- `test/it/it_month_name_little_endian.test.ts`: For month name expressions.