### PR TITLE
test(zh): Add more weekday tests for zh locales

### DIFF
--- a/test/zh/hans/zh_hans_weekday.test.ts
+++ b/test/zh/hans/zh_hans_weekday.test.ts
@@ -124,6 +124,17 @@ test("Test - 'this' week", function () {
         const expectDate = new Date(2012, 7, 6, 12);
         expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
     });
+
+    testSingleCase(chrono.zh.hans, "星期一", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(13);
+        expect(result.start.get("weekday")).toBe(1);
+
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 8 - 1, 13, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
 });
 
 test("Test - Range with different separators", function () {

--- a/test/zh/hant/zh_hant_weekday.test.ts
+++ b/test/zh/hant/zh_hant_weekday.test.ts
@@ -109,6 +109,34 @@ test("Test - Single Expression", function () {
     });
 });
 
+test("Test - 'this' week", function () {
+    testSingleCase(chrono.zh.hant, "我這個星期一要打遊戲", new Date(2012, 7, 10), (result) => {
+        expect(result.index).toBe(1);
+        expect(result.text).toBe("這個星期一");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 7, 6, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+
+    testSingleCase(chrono.zh.hant, "星期一", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(13);
+        expect(result.start.get("weekday")).toBe(1);
+
+        const resultDate = result.start.date();
+        const expectDate = new Date(2012, 8 - 1, 13, 12);
+        expect(expectDate.getTime()).toBeCloseTo(resultDate.getTime());
+    });
+});
+
 test("Test - forward dates only option", function () {
     testSingleCase(chrono.zh.hant, "星期六-星期一", new Date(2016, 9 - 1, 2), { forwardDate: true }, (result) => {
         expect(result.index).toBe(0);


### PR DESCRIPTION
Add test cases for zh/hans and zh/hant to increase test coverage.

- In zh/hans weekday test, add case where prefix (e.g. "this") is missing and the closest date window should be calculated.
- In zh/hant weekday test, add "this" prefix case as well as when the prefix is missing.