### PR TITLE
Change default implied hour from 12 to 0

### DIFF
--- a/src/results.ts
+++ b/src/results.ts
@@ -80,7 +80,7 @@ export class ParsingComponents implements ParsedComponents {
         this.imply("day", date.getDate());
         this.imply("month", date.getMonth() + 1);
         this.imply("year", date.getFullYear());
-        this.imply("hour", 12);
+        this.imply("hour", 0);
         this.imply("minute", 0);
         this.imply("second", 0);
         this.imply("millisecond", 0);


### PR DESCRIPTION
12 = 12pm
0 = midnight

When I try to specify "9/26/25" the default time is set to 12pm instead of midnight, which is confusing and not aligned with the [docs](https://www.npmjs.com/package/chrono-node)
<img width="868" height="448" alt="image" src="https://github.com/user-attachments/assets/37272ef7-e58d-4591-b1ec-c39dfac7484d" />


https://github.com/wanasit/chrono/issues/631