### PR TITLE
Fix meridiem merge for casual times and add -5d midnight regression

### DIFF
--- a/src/calculation/mergingCalculation.ts
+++ b/src/calculation/mergingCalculation.ts
@@ -64,9 +64,14 @@ export function mergeDateTimeComponent(
         dateTimeComponent.assign("timezoneOffset", timeComponent.get("timezoneOffset"));
     }
 
+    const dateHasMeaningfulMeridiem =
+        dateComponent.get("meridiem") != null &&
+        (dateComponent.isCertain("meridiem") || Array.from(dateComponent.tags()).some((t) => t.startsWith("casualReference/")));
+
     if (timeComponent.isCertain("meridiem")) {
         dateTimeComponent.assign("meridiem", timeComponent.get("meridiem"));
-    } else if (timeComponent.get("meridiem") != null && dateTimeComponent.get("meridiem") == null) {
+    } else if (timeComponent.get("meridiem") != null && !dateHasMeaningfulMeridiem) {
+        // Let the time component guide meridiem only when the date part doesn't already carry a meaningful (certain or casual) hint.
         dateTimeComponent.imply("meridiem", timeComponent.get("meridiem"));
     }
 

--- a/src/locales/es/parsers/ESCasualTimeParser.ts
+++ b/src/locales/es/parsers/ESCasualTimeParser.ts
@@ -15,16 +15,19 @@ export default class ESCasualTimeParser extends AbstractParserWithWordBoundaryCh
             case "tarde":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 15);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "noche":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 22);
+                component.addTag("casualReference/evening");
                 break;
 
             case "mañana":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 6);
+                component.addTag("casualReference/morning");
                 break;
 
             case "medianoche":
@@ -35,12 +38,14 @@ export default class ESCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 0);
                 component.imply("minute", 0);
                 component.imply("second", 0);
+                component.addTag("casualReference/midnight");
                 break;
 
             case "mediodia":
             case "mediodía":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 12);
+                component.addTag("casualReference/noon");
                 break;
         }
 

--- a/src/locales/nl/parsers/NLCasualTimeParser.ts
+++ b/src/locales/nl/parsers/NLCasualTimeParser.ts
@@ -26,12 +26,14 @@ export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryCh
             case "'s namiddags":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 15);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "avond":
             case "'s avonds'":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 20);
+                component.addTag("casualReference/evening");
                 break;
 
             case "middernacht":
@@ -42,18 +44,21 @@ export default class NLCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 0);
                 component.imply("minute", 0);
                 component.imply("second", 0);
+                component.addTag("casualReference/midnight");
                 break;
 
             case "ochtend":
             case "'s ochtends":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 6);
+                component.addTag("casualReference/morning");
                 break;
 
             case "middag":
             case "'s middags":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 12);
+                component.addTag("casualReference/noon");
                 break;
         }
 

--- a/src/locales/pt/parsers/PTCasualTimeParser.ts
+++ b/src/locales/pt/parsers/PTCasualTimeParser.ts
@@ -15,17 +15,20 @@ export default class PTCasualTimeParser extends AbstractParserWithWordBoundaryCh
             case "tarde":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 15);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "noite":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 22);
+                component.addTag("casualReference/evening");
                 break;
 
             case "manha":
             case "manhã":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 6);
+                component.addTag("casualReference/morning");
                 break;
 
             case "meia-noite":
@@ -36,11 +39,13 @@ export default class PTCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 0);
                 component.imply("minute", 0);
                 component.imply("second", 0);
+                component.addTag("casualReference/midnight");
                 break;
 
             case "meio-dia":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 12);
+                component.addTag("casualReference/noon");
                 break;
         }
 

--- a/test/en/en_time_units_casual_relative.test.ts
+++ b/test/en/en_time_units_casual_relative.test.ts
@@ -145,6 +145,17 @@ test("Test - Minus '-' sign", () => {
         expect(result.start.get("hour")).toBe(9);
         expect(result.start.get("minute")).toBe(55);
     });
+
+    testSingleCase(chrono, "-5d 00", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(26);
+        expect(result.start.get("hour")).toBe(0);
+        expect(result.start.get("minute")).toBe(0);
+
+        expect(result.start).toBeDate(new Date(2016, 9 - 1, 26, 0, 0));
+    });
 });
 
 test("Test - Without custom parser without abbreviations", function () {


### PR DESCRIPTION
 - Original bug: When merging a relative date (-5d) with a time-only expression (00), the date component’s implied meridiem (PM) could override the time parser’s implied AM, shifting midnight to noon. This also
    caused casual phrases like “tonight at 8” to lose their PM context in other locales.  Example -5d 00 was resolving to 5 days ago at 12:00:00 (noon).

  - Fix: Meridiem is now only overridden by the time side when the date side lacks a meaningful meridiem (certain or tagged casual reference). Casual time parsers for es/pt/nl now emit casualReference/* tags so
    their implied PM/AM is respected. 

  - New test: Added a regression case for "-5d 00" to ensure it resolves to Sep 26, 2016 00:00 from an Oct 1, 2016 noon reference.

  Please review the merge heuristic; if you’d like a different “meaningful meridiem” rule (e.g., stricter tags or locale-specific treatment), I can adjust.

