### PR TITLE
feat: Add Finnish (fi) locale support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,9 @@ import * as es from "./locales/es";
 import * as uk from "./locales/uk";
 import * as it from "./locales/it";
 import * as sv from "./locales/sv";
+import * as fi from "./locales/fi";
 
-export { de, fr, ja, pt, nl, zh, ru, es, uk, it, sv };
+export { de, fr, ja, pt, nl, zh, ru, es, uk, it, sv, fi };
 
 /**
  * A shortcut for {@link en | chrono.en.strict}

--- a/src/locales/fi/constants.ts
+++ b/src/locales/fi/constants.ts
@@ -1,0 +1,209 @@
+import { matchAnyPattern, repeatedTimeunitPattern } from "../../utils/pattern";
+import { findMostLikelyADYear } from "../../calculation/years";
+import { Duration } from "../../calculation/duration";
+import { Timeunit } from "../../types";
+
+export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
+    "sunnuntai": 0,
+    "sunnuntaina": 0,
+    "su": 0,
+    "maanantai": 1,
+    "maanantaina": 1,
+    "ma": 1,
+    "tiistai": 2,
+    "tiistaina": 2,
+    "ti": 2,
+    "keskiviikko": 3,
+    "keskiviikkona": 3,
+    "ke": 3,
+    "torstai": 4,
+    "torstaina": 4,
+    "to": 4,
+    "perjantai": 5,
+    "perjantaina": 5,
+    "pe": 5,
+    "lauantai": 6,
+    "lauantaina": 6,
+    "la": 6,
+};
+
+export const MONTH_DICTIONARY: { [word: string]: number } = {
+    "tammikuu": 1,
+    "tammikuuta": 1,
+    "tammikuun": 1,
+    "tammi": 1,
+    "helmikuu": 2,
+    "helmikuuta": 2,
+    "helmikuun": 2,
+    "helmi": 2,
+    "maaliskuu": 3,
+    "maaliskuuta": 3,
+    "maaliskuun": 3,
+    "maalis": 3,
+    "huhtikuu": 4,
+    "huhtikuuta": 4,
+    "huhtikuun": 4,
+    "huhti": 4,
+    "toukokuu": 5,
+    "toukokuuta": 5,
+    "toukokuun": 5,
+    "touko": 5,
+    "kesäkuu": 6,
+    "kesäkuuta": 6,
+    "kesäkuun": 6,
+    "kesä": 6,
+    "heinäkuu": 7,
+    "heinäkuuta": 7,
+    "heinäkuun": 7,
+    "heinä": 7,
+    "elokuu": 8,
+    "elokuuta": 8,
+    "elokuun": 8,
+    "elo": 8,
+    "syyskuu": 9,
+    "syyskuuta": 9,
+    "syyskuun": 9,
+    "syys": 9,
+    "lokakuu": 10,
+    "lokakuuta": 10,
+    "lokakuun": 10,
+    "loka": 10,
+    "marraskuu": 11,
+    "marraskuuta": 11,
+    "marraskuun": 11,
+    "marras": 11,
+    "joulukuu": 12,
+    "joulukuuta": 12,
+    "joulukuun": 12,
+    "joulu": 12,
+};
+
+export const INTEGER_WORD_DICTIONARY: { [word: string]: number } = {
+    "yksi": 1,
+    "yhden": 1,
+    "kaksi": 2,
+    "kahden": 2,
+    "kolme": 3,
+    "kolmen": 3,
+    "neljä": 4,
+    "neljän": 4,
+    "viisi": 5,
+    "viiden": 5,
+    "kuusi": 6,
+    "kuuden": 6,
+    "seitsemän": 7,
+    "kahdeksan": 8,
+    "yhdeksän": 9,
+    "kymmenen": 10,
+};
+
+export const TIME_UNIT_DICTIONARY: { [word: string]: Timeunit } = {
+    "s": "second",
+    "sek": "second",
+    "sekunti": "second",
+    "sekuntia": "second",
+    "sekunnin": "second",
+    "min": "minute",
+    "minuutti": "minute",
+    "minuuttia": "minute",
+    "minuutin": "minute",
+    "t": "hour",
+    "tunti": "hour",
+    "tuntia": "hour",
+    "tunnin": "hour",
+    "pv": "day",
+    "päivä": "day",
+    "päivää": "day",
+    "päivän": "day",
+    "vk": "week",
+    "viikko": "week",
+    "viikkoa": "week",
+    "viikon": "week",
+    "kk": "month",
+    "kuukausi": "month",
+    "kuukautta": "month",
+    "kuukauden": "month",
+    "vuosi": "year",
+    "vuotta": "year",
+    "vuoden": "year",
+};
+
+export const TIME_UNIT_NO_ABBR_DICTIONARY: { [word: string]: Timeunit } = {
+    "sekunti": "second",
+    "sekuntia": "second",
+    "sekunnin": "second",
+    "minuutti": "minute",
+    "minuuttia": "minute",
+    "minuutin": "minute",
+    "tunti": "hour",
+    "tuntia": "hour",
+    "tunnin": "hour",
+    "päivä": "day",
+    "päivää": "day",
+    "päivän": "day",
+    "viikko": "week",
+    "viikkoa": "week",
+    "viikon": "week",
+    "kuukausi": "month",
+    "kuukautta": "month",
+    "kuukauden": "month",
+    "vuosi": "year",
+    "vuotta": "year",
+    "vuoden": "year",
+};
+
+export function parseDuration(timeunitText: string): Duration {
+    const fragments: { [key: string]: number } = {};
+    let remainingText = timeunitText;
+    let match = SINGLE_TIME_UNIT_REGEX.exec(remainingText);
+    while (match) {
+        collectDateTimeFragment(fragments, match);
+        remainingText = remainingText.substring(match[0].length);
+        match = SINGLE_TIME_UNIT_REGEX.exec(remainingText);
+    }
+    return fragments as Duration;
+}
+
+function collectDateTimeFragment(fragments: { [key: string]: number }, match: RegExpMatchArray) {
+    const num = parseNumberPattern(match[1]);
+    const unit = TIME_UNIT_DICTIONARY[match[2].toLowerCase()];
+    fragments[unit] = num;
+}
+
+export const NUMBER_PATTERN = `(?:${matchAnyPattern(INTEGER_WORD_DICTIONARY)}|\\d+)`;
+export const TIME_UNIT_PATTERN = `(?:${matchAnyPattern(TIME_UNIT_DICTIONARY)})`;
+
+const SINGLE_TIME_UNIT_PATTERN = `(${NUMBER_PATTERN})\\s{0,5}(${matchAnyPattern(TIME_UNIT_DICTIONARY)})\\s{0,5}`;
+const SINGLE_TIME_UNIT_REGEX = new RegExp(SINGLE_TIME_UNIT_PATTERN, "i");
+
+const SINGLE_TIME_UNIT_NO_ABBR_PATTERN = `(${NUMBER_PATTERN})\\s{0,5}(${matchAnyPattern(
+    TIME_UNIT_NO_ABBR_DICTIONARY
+)})\\s{0,5}`;
+
+export const TIME_UNITS_PATTERN = repeatedTimeunitPattern("", SINGLE_TIME_UNIT_PATTERN);
+export const TIME_UNITS_NO_ABBR_PATTERN = repeatedTimeunitPattern("", SINGLE_TIME_UNIT_NO_ABBR_PATTERN);
+
+export function parseNumberPattern(match: string): number {
+    const num = match.toLowerCase();
+    if (INTEGER_WORD_DICTIONARY[num] !== undefined) {
+        return INTEGER_WORD_DICTIONARY[num];
+    }
+    return parseInt(num);
+}
+
+export function parseYear(match: string): number {
+    if (/\d+/.test(match)) {
+        let yearNumber = parseInt(match);
+        if (yearNumber < 100) {
+            yearNumber = findMostLikelyADYear(yearNumber);
+        }
+        return yearNumber;
+    }
+
+    const num = match.toLowerCase();
+    if (INTEGER_WORD_DICTIONARY[num] !== undefined) {
+        return INTEGER_WORD_DICTIONARY[num];
+    }
+
+    return parseInt(match);
+}

--- a/src/locales/fi/index.ts
+++ b/src/locales/fi/index.ts
@@ -1,0 +1,57 @@
+import { includeCommonConfiguration } from "../../configurations";
+import { Chrono, Configuration, Parser, Refiner } from "../../chrono";
+import { ParsingResult, ParsingComponents, ReferenceWithTimezone } from "../../results";
+import { Component, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday } from "../../types";
+import SlashDateFormatParser from "../../common/parsers/SlashDateFormatParser";
+import ISOFormatParser from "../../common/parsers/ISOFormatParser";
+import FITimeExpressionParser from "./parsers/FITimeExpressionParser";
+import FIWeekdayParser from "./parsers/FIWeekdayParser";
+import FIMonthNameLittleEndianParser from "./parsers/FIMonthNameLittleEndianParser";
+import FITimeUnitCasualRelativeFormatParser from "./parsers/FITimeUnitCasualRelativeFormatParser";
+import FITimeUnitAgoFormatParser from "./parsers/FITimeUnitAgoFormatParser";
+import FITimeUnitWithinFormatParser from "./parsers/FITimeUnitWithinFormatParser";
+import FICasualDateParser from "./parsers/FICasualDateParser";
+import FICasualTimeParser from "./parsers/FICasualTimeParser";
+import FIMergeDateRangeRefiner from "./refiners/FIMergeDateRangeRefiner";
+import FIMergeDateTimeRefiner from "./refiners/FIMergeDateTimeRefiner";
+
+export { Chrono, Parser, Refiner, ParsingResult, ParsingComponents, ReferenceWithTimezone };
+export { Component, ParsedResult, ParsingOption, ParsingReference, Meridiem, Weekday };
+
+// Shortcuts
+export const casual = new Chrono(createCasualConfiguration());
+export const strict = new Chrono(createConfiguration(true));
+
+export function parse(text: string, ref?: ParsingReference | Date, option?: ParsingOption): ParsedResult[] {
+    return casual.parse(text, ref, option);
+}
+
+export function parseDate(text: string, ref?: ParsingReference | Date, option?: ParsingOption): Date {
+    return casual.parseDate(text, ref, option);
+}
+
+export function createCasualConfiguration(littleEndian = true): Configuration {
+    const option = createConfiguration(false, littleEndian);
+    option.parsers.unshift(new FICasualTimeParser());
+    option.parsers.unshift(new FICasualDateParser());
+    option.parsers.unshift(new FITimeUnitCasualRelativeFormatParser());
+    return option;
+}
+
+export function createConfiguration(strictMode = true, littleEndian = true): Configuration {
+    return includeCommonConfiguration(
+        {
+            parsers: [
+                new ISOFormatParser(),
+                new SlashDateFormatParser(littleEndian),
+                new FITimeExpressionParser(),
+                new FIMonthNameLittleEndianParser(),
+                new FIWeekdayParser(),
+                new FITimeUnitWithinFormatParser(),
+                new FITimeUnitAgoFormatParser(),
+            ],
+            refiners: [new FIMergeDateRangeRefiner(), new FIMergeDateTimeRefiner()],
+        },
+        strictMode
+    );
+}

--- a/src/locales/fi/parsers/FICasualDateParser.ts
+++ b/src/locales/fi/parsers/FICasualDateParser.ts
@@ -1,0 +1,82 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents, ParsingResult } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { assignSimilarDate, implySimilarTime } from "../../../utils/dates";
+import FICasualTimeParser from "./FICasualTimeParser";
+import * as references from "../../../common/casualReferences";
+import { addDuration } from "../../../calculation/duration";
+
+const PATTERN = new RegExp(
+    `(nyt|tänään|huomenna|ylihuomenna|eilen|toissapäivänä|viime\\s*yönä)` +
+        `(?:\\s*(aamulla|aamuna|aamupäivällä|päivällä|iltapäivällä|illalla|yöllä|keskiyöllä))?` +
+        `(?=\\W|$)`,
+    "i"
+);
+
+const DATE_GROUP = 1;
+const TIME_GROUP = 2;
+
+export default class FICasualDateParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(context: ParsingContext): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
+        let targetDate = context.reference.getDateWithAdjustedTimezone();
+        const dateKeyword = (match[DATE_GROUP] || "").toLowerCase();
+        const timeKeyword = (match[TIME_GROUP] || "").toLowerCase();
+
+        let component = context.createParsingComponents();
+        switch (dateKeyword) {
+            case "nyt":
+                component = references.now(context.reference);
+                break;
+
+            case "tänään":
+                component = references.today(context.reference);
+                break;
+
+            case "huomenna":
+                targetDate = addDuration(targetDate, { day: 1 });
+                assignSimilarDate(component, targetDate);
+                implySimilarTime(component, targetDate);
+                break;
+
+            case "ylihuomenna":
+                targetDate = addDuration(targetDate, { day: 2 });
+                assignSimilarDate(component, targetDate);
+                implySimilarTime(component, targetDate);
+                break;
+
+            case "eilen":
+                targetDate = addDuration(targetDate, { day: -1 });
+                assignSimilarDate(component, targetDate);
+                implySimilarTime(component, targetDate);
+                break;
+
+            case "toissapäivänä":
+                targetDate = addDuration(targetDate, { day: -2 });
+                assignSimilarDate(component, targetDate);
+                implySimilarTime(component, targetDate);
+                break;
+
+            default:
+                if (dateKeyword.match(/viime\s*yönä/)) {
+                    if (targetDate.getHours() > 6) {
+                        targetDate = addDuration(targetDate, { day: -1 });
+                    }
+
+                    assignSimilarDate(component, targetDate);
+                    component.imply("hour", 0);
+                }
+
+                break;
+        }
+
+        if (timeKeyword) {
+            component = FICasualTimeParser.extractTimeComponents(component, timeKeyword);
+        }
+
+        return component;
+    }
+}

--- a/src/locales/fi/parsers/FICasualTimeParser.ts
+++ b/src/locales/fi/parsers/FICasualTimeParser.ts
@@ -1,0 +1,78 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents, ParsingResult } from "../../../results";
+import { Meridiem } from "../../../types";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { implySimilarTime } from "../../../utils/dates";
+
+export default class FICasualTimeParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(context: ParsingContext): RegExp {
+        return /(tänä\s*)?(aamulla|aamuna|aamupäivällä|päivällä|iltapäivällä|illalla|yöllä|keskiyöllä)(?=\W|$)/i;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult {
+        const targetDate = context.refDate;
+        const timeKeywordPattern = match[2].toLowerCase();
+        const component = context.createParsingComponents();
+        implySimilarTime(component, targetDate);
+        return FICasualTimeParser.extractTimeComponents(component, timeKeywordPattern);
+    }
+
+    static extractTimeComponents(component: ParsingComponents, timeKeywordPattern: string): ParsingComponents {
+        switch (timeKeywordPattern) {
+            case "aamulla":
+            case "aamuna":
+                component.imply("hour", 6);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.AM);
+                break;
+
+            case "aamupäivällä":
+                component.imply("hour", 9);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.AM);
+                break;
+
+            case "päivällä":
+                component.imply("hour", 12);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.AM);
+                break;
+
+            case "iltapäivällä":
+                component.imply("hour", 15);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.PM);
+                break;
+
+            case "illalla":
+                component.imply("hour", 18);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.PM);
+                break;
+
+            case "yöllä":
+                component.imply("hour", 22);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.PM);
+                break;
+
+            case "keskiyöllä":
+                if (component.get("hour") > 1) {
+                    component.addDurationAsImplied({ "day": 1 });
+                }
+
+                component.imply("hour", 0);
+                component.imply("minute", 0);
+                component.imply("second", 0);
+                component.imply("meridiem", Meridiem.AM);
+                break;
+        }
+        return component;
+    }
+}

--- a/src/locales/fi/parsers/FIMonthNameLittleEndianParser.ts
+++ b/src/locales/fi/parsers/FIMonthNameLittleEndianParser.ts
@@ -1,0 +1,57 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingResult } from "../../../results";
+import { findYearClosestToRef } from "../../../calculation/years";
+import { MONTH_DICTIONARY } from "../constants";
+import { parseYear } from "../constants";
+import { matchAnyPattern } from "../../../utils/pattern";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+
+const PATTERN = new RegExp(
+    `([0-9]{1,2})\\.?` +
+        `(?:\\s*(?:\\-|\\–|\\s)\\s*([0-9]{1,2})\\.?)?\\s*` +
+        `(${matchAnyPattern(MONTH_DICTIONARY)})` +
+        `(?:(?:-|/|,?\\s*)([0-9]{4}(?![^\\s]\\d)))?` +
+        `(?=\\W|$)`,
+    "i"
+);
+
+const DATE_GROUP = 1;
+const DATE_TO_GROUP = 2;
+const MONTH_NAME_GROUP = 3;
+const YEAR_GROUP = 4;
+
+export default class FIMonthNameLittleEndianParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingResult {
+        const result = context.createParsingResult(match.index, match[0]);
+
+        const month = MONTH_DICTIONARY[match[MONTH_NAME_GROUP].toLowerCase()];
+        const day = parseInt(match[DATE_GROUP]);
+        if (day > 31) {
+            match.index = match.index + match[DATE_GROUP].length;
+            return null;
+        }
+
+        result.start.assign("month", month);
+        result.start.assign("day", day);
+
+        if (match[YEAR_GROUP]) {
+            const yearNumber = parseYear(match[YEAR_GROUP]);
+            result.start.assign("year", yearNumber);
+        } else {
+            const year = findYearClosestToRef(context.refDate, day, month);
+            result.start.imply("year", year);
+        }
+
+        if (match[DATE_TO_GROUP]) {
+            const endDate = parseInt(match[DATE_TO_GROUP]);
+            result.end = result.start.clone();
+            result.end.assign("day", endDate);
+        }
+
+        return result;
+    }
+}

--- a/src/locales/fi/parsers/FITimeExpressionParser.ts
+++ b/src/locales/fi/parsers/FITimeExpressionParser.ts
@@ -1,0 +1,22 @@
+import { AbstractTimeExpressionParser } from "../../../common/parsers/AbstractTimeExpressionParser";
+import { ParsingComponents } from "../../../results";
+import { ParsingContext } from "../../../chrono";
+
+export default class FITimeExpressionParser extends AbstractTimeExpressionParser {
+    primaryPrefix(): string {
+        return "(?:(?:klo|kello)\\s*)?";
+    }
+
+    followingPhase(): string {
+        return "\\s*(?:\\-|\\–|\\~|\\〜)\\s*";
+    }
+
+    extractPrimaryTimeComponents(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | null {
+        // This looks more like a year e.g. 2020
+        if (match[0].match(/^\s*\d{4}\s*$/)) {
+            return null;
+        }
+
+        return super.extractPrimaryTimeComponents(context, match);
+    }
+}

--- a/src/locales/fi/parsers/FITimeUnitAgoFormatParser.ts
+++ b/src/locales/fi/parsers/FITimeUnitAgoFormatParser.ts
@@ -1,0 +1,18 @@
+import { ParsingContext } from "../../../chrono";
+import { parseDuration, TIME_UNITS_PATTERN } from "../constants";
+import { ParsingComponents } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { reverseDuration } from "../../../calculation/duration";
+
+export default class FITimeUnitAgoFormatParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return new RegExp(`(${TIME_UNITS_PATTERN})\\s*sitten(?=\\W|$)`, "i");
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray) {
+        const timeUnits = parseDuration(match[1]);
+        const outputTimeUnits = reverseDuration(timeUnits);
+
+        return ParsingComponents.createRelativeFromReference(context.reference, outputTimeUnits);
+    }
+}

--- a/src/locales/fi/parsers/FITimeUnitCasualRelativeFormatParser.ts
+++ b/src/locales/fi/parsers/FITimeUnitCasualRelativeFormatParser.ts
@@ -1,0 +1,47 @@
+import { TIME_UNITS_PATTERN, parseDuration, TIME_UNITS_NO_ABBR_PATTERN } from "../constants";
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { reverseDuration } from "../../../calculation/duration";
+
+const PATTERN = new RegExp(
+    `(seuraava|seuraavat|seuraavien|edellinen|edelliset|edellisten|viimeiset|viimeisten|kuluneet|kuluneiden|\\+|-)\\s*(${TIME_UNITS_PATTERN})(?=\\W|$)`,
+    "i"
+);
+const PATTERN_NO_ABBR = new RegExp(
+    `(seuraava|seuraavat|seuraavien|edellinen|edelliset|edellisten|viimeiset|viimeisten|kuluneet|kuluneiden|\\+|-)\\s*(${TIME_UNITS_NO_ABBR_PATTERN})(?=\\W|$)`,
+    "i"
+);
+
+export default class FITimeUnitCasualRelativeFormatParser extends AbstractParserWithWordBoundaryChecking {
+    constructor(private allowAbbreviations: boolean = true) {
+        super();
+    }
+
+    innerPattern(): RegExp {
+        return this.allowAbbreviations ? PATTERN : PATTERN_NO_ABBR;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray) {
+        const prefix = match[1].toLowerCase();
+        let duration = parseDuration(match[2]);
+        if (!duration) {
+            return null;
+        }
+
+        switch (prefix) {
+            case "edellinen":
+            case "edelliset":
+            case "edellisten":
+            case "viimeiset":
+            case "viimeisten":
+            case "kuluneet":
+            case "kuluneiden":
+            case "-":
+                duration = reverseDuration(duration);
+                break;
+        }
+
+        return ParsingComponents.createRelativeFromReference(context.reference, duration);
+    }
+}

--- a/src/locales/fi/parsers/FITimeUnitWithinFormatParser.ts
+++ b/src/locales/fi/parsers/FITimeUnitWithinFormatParser.ts
@@ -1,0 +1,15 @@
+import { TIME_UNITS_PATTERN, parseDuration } from "../constants";
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+
+export default class FITimeUnitWithinFormatParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return new RegExp(`(${TIME_UNITS_PATTERN})\\s*(?:sisällä|kuluessa|päästä)(?=\\W|$)`, "i");
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
+        const timeUnits = parseDuration(match[1]);
+        return ParsingComponents.createRelativeFromReference(context.reference, timeUnits);
+    }
+}

--- a/src/locales/fi/parsers/FIWeekdayParser.ts
+++ b/src/locales/fi/parsers/FIWeekdayParser.ts
@@ -1,0 +1,46 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents } from "../../../results";
+import { WEEKDAY_DICTIONARY } from "../constants";
+import { matchAnyPattern } from "../../../utils/pattern";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { createParsingComponentsAtWeekday } from "../../../calculation/weekdays";
+
+const PATTERN = new RegExp(
+    "(?:(?:\\,|\\(|\\（)\\s*)?" +
+        "(?:(viime|edellinen|edellisenä|ensi|seuraava|seuraavana|tämä|tänä)\\s*)?" +
+        `(${matchAnyPattern(WEEKDAY_DICTIONARY)})` +
+        "(?:\\s*(?:\\,|\\)|\\）))?" +
+        "(?:\\s*(viime|ensi|seuraava)\\s*viikolla)?" +
+        "(?=\\W|$)",
+    "i"
+);
+
+const PREFIX_GROUP = 1;
+const WEEKDAY_GROUP = 2;
+const SUFFIX_GROUP = 3;
+
+export default class FIWeekdayParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents {
+        const dayOfWeek = match[WEEKDAY_GROUP].toLowerCase();
+        const offset = WEEKDAY_DICTIONARY[dayOfWeek];
+        const prefix = match[PREFIX_GROUP];
+        const postfix = match[SUFFIX_GROUP];
+
+        let modifierWord = prefix || postfix;
+        modifierWord = modifierWord || "";
+        modifierWord = modifierWord.toLowerCase();
+
+        let modifier = null;
+        if (modifierWord.match(/viime|edellinen|edellisenä/)) {
+            modifier = "last";
+        } else if (modifierWord.match(/ensi|seuraava|seuraavana/)) {
+            modifier = "next";
+        }
+
+        return createParsingComponentsAtWeekday(context.reference, offset, modifier);
+    }
+}

--- a/src/locales/fi/refiners/FIMergeDateRangeRefiner.ts
+++ b/src/locales/fi/refiners/FIMergeDateRangeRefiner.ts
@@ -1,0 +1,7 @@
+import AbstractMergeDateRangeRefiner from "../../../common/refiners/AbstractMergeDateRangeRefiner";
+
+export default class FIMergeDateRangeRefiner extends AbstractMergeDateRangeRefiner {
+    patternBetween(): RegExp {
+        return /^\s*(-|–)\s*$/i;
+    }
+}

--- a/src/locales/fi/refiners/FIMergeDateTimeRefiner.ts
+++ b/src/locales/fi/refiners/FIMergeDateTimeRefiner.ts
@@ -1,0 +1,7 @@
+import AbstractMergeDateTimeRefiner from "../../../common/refiners/AbstractMergeDateTimeRefiner";
+
+export default class FIMergeDateTimeRefiner extends AbstractMergeDateTimeRefiner {
+    patternBetween(): RegExp {
+        return new RegExp("^\\s*(T|klo|kello|,|-)?\\s*$");
+    }
+}

--- a/test/fi/fi_casual.test.ts
+++ b/test/fi/fi_casual.test.ts
@@ -1,0 +1,85 @@
+import * as chrono from "../../src/locales/fi";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", function () {
+    testSingleCase(chrono, "tänään", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+    });
+
+    testSingleCase(chrono, "huomenna", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(11);
+    });
+
+    testSingleCase(chrono, "eilen", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+    });
+
+    testSingleCase(chrono, "ylihuomenna", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12);
+    });
+
+    testSingleCase(chrono, "toissapäivänä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(8);
+    });
+});
+
+test("Test - Combined Expression", function () {
+    testSingleCase(chrono, "tänään aamulla", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(6);
+    });
+
+    testSingleCase(chrono, "tänään aamupäivällä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(9);
+    });
+
+    testSingleCase(chrono, "tänään päivällä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono, "tänään iltapäivällä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(15);
+    });
+
+    testSingleCase(chrono, "tänään illalla", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(18);
+    });
+
+    testSingleCase(chrono, "tänään yöllä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(22);
+    });
+
+    testSingleCase(chrono, "tänään keskiyöllä", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(0);
+    });
+});

--- a/test/fi/fi_casual_time.test.ts
+++ b/test/fi/fi_casual_time.test.ts
@@ -1,0 +1,56 @@
+import * as chrono from "../../src/locales/fi";
+import { testSingleCase } from "../test_util";
+
+test("Test - Standalone casual time expressions", function () {
+    testSingleCase(chrono, "aamulla", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("aamulla");
+        expect(result.start.get("hour")).toBe(6);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "aamupäivällä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("aamupäivällä");
+        expect(result.start.get("hour")).toBe(9);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "päivällä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("päivällä");
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "iltapäivällä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("iltapäivällä");
+        expect(result.start.get("hour")).toBe(15);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "illalla", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("illalla");
+        expect(result.start.get("hour")).toBe(18);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "yöllä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("yöllä");
+        expect(result.start.get("hour")).toBe(22);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "keskiyöllä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("keskiyöllä");
+        expect(result.start.get("hour")).toBe(0);
+        expect(result.start.get("minute")).toBe(0);
+    });
+});
+
+test("Test - 'viime yönä' (last night)", function () {
+    testSingleCase(chrono, "viime yönä", new Date(2012, 7, 10, 14, 0), (result) => {
+        expect(result.text).toBe("viime yönä");
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9);
+        expect(result.start.get("hour")).toBe(0);
+    });
+});

--- a/test/fi/fi_month_name_little_endian.test.ts
+++ b/test/fi/fi_month_name_little_endian.test.ts
@@ -1,0 +1,50 @@
+import * as chrono from "../../src/locales/fi";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
+
+test("Test - Single expression", function () {
+    testSingleCase(chrono, "15. elokuuta", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono, "15 elokuuta 2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono, "15. elo 2012", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono, "3 tammikuuta", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2013);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(3);
+    });
+
+    testSingleCase(chrono, "1 joulukuuta 2023", new Date(2023, 10, 1), (result) => {
+        expect(result.start.get("year")).toBe(2023);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(1);
+    });
+});
+
+test("Test - Range expression", function () {
+    testSingleCase(chrono, "15-16 elokuuta", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.end.get("year")).toBe(2012);
+        expect(result.end.get("month")).toBe(8);
+        expect(result.end.get("day")).toBe(16);
+    });
+});
+
+test("Test - Impossible Dates", function () {
+    testUnexpectedResult(chrono, "32 elokuuta", new Date(2012, 7, 10));
+});

--- a/test/fi/fi_time_exp.test.ts
+++ b/test/fi/fi_time_exp.test.ts
@@ -1,0 +1,39 @@
+import * as chrono from "../../src/locales/fi";
+import { testSingleCase } from "../test_util";
+
+test("Test - Time expression", function () {
+    testSingleCase(chrono, "klo 15:00", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("hour")).toBe(15);
+        expect(result.start.get("minute")).toBe(0);
+    });
+
+    testSingleCase(chrono, "kello 8:30", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("hour")).toBe(8);
+        expect(result.start.get("minute")).toBe(30);
+    });
+
+    testSingleCase(chrono, "klo 13.00", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("hour")).toBe(13);
+        expect(result.start.get("minute")).toBe(0);
+    });
+});
+
+test("Test - Time range expression", function () {
+    testSingleCase(chrono, "klo 10:00-12:00", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("hour")).toBe(10);
+        expect(result.start.get("minute")).toBe(0);
+
+        expect(result.end.get("hour")).toBe(12);
+        expect(result.end.get("minute")).toBe(0);
+    });
+});
+
+test("Test - Date and time expression", function () {
+    testSingleCase(chrono, "15 elokuuta 2012 klo 14:00", new Date(2012, 7, 10), (result) => {
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(0);
+    });
+});

--- a/test/fi/fi_time_units_ago.test.ts
+++ b/test/fi/fi_time_units_ago.test.ts
@@ -1,0 +1,103 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", function () {
+    testSingleCase(chrono.fi, "5 päivää sitten tehtiin jotain", new Date(2012, 8 - 1, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(5);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5 päivää sitten");
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 5));
+    });
+
+    testSingleCase(chrono.fi, "10 päivää sitten tehtiin jotain", new Date(2012, 7, 10, 13, 30), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(31);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("10 päivää sitten");
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 31, 13, 30));
+    });
+
+    testSingleCase(chrono.fi, "15 minuuttia sitten", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("15 minuuttia sitten");
+        expect(result.start.get("hour")).toBe(11);
+        expect(result.start.get("minute")).toBe(59);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 11, 59));
+    });
+
+    testSingleCase(chrono.fi, "   12 tuntia sitten", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(3);
+        expect(result.text).toBe("12 tuntia sitten");
+        expect(result.start.get("hour")).toBe(0);
+        expect(result.start.get("minute")).toBe(14);
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 0, 14));
+    });
+
+    testSingleCase(
+        chrono.fi,
+        "12 tuntia sitten tapahtui jotain",
+        new Date(2012, 7, 10, 12, 14),
+        (result) => {
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("12 tuntia sitten");
+            expect(result.start.get("hour")).toBe(0);
+            expect(result.start.get("minute")).toBe(14);
+
+            expect(result.start).toBeDate(new Date(2012, 7, 10, 0, 14));
+        }
+    );
+});
+
+test("Test - Single Expression (Casual)", function () {
+    testSingleCase(chrono.fi, "5 kuukautta sitten tehtiin jotain", new Date(2012, 10 - 1, 10), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(5);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5 kuukautta sitten");
+
+        expect(result.start).toBeDate(new Date(2012, 5 - 1, 10));
+    });
+
+    testSingleCase(chrono.fi, "5 vuotta sitten tehtiin jotain", new Date(2012, 8 - 1, 10, 22, 22), (result) => {
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2007);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(10);
+
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5 vuotta sitten");
+
+        expect(result.start).toBeDate(new Date(2007, 8 - 1, 10, 22, 22));
+    });
+
+    testSingleCase(
+        chrono.fi,
+        "yksi viikkoa sitten tehtiin jotain",
+        new Date(2012, 8 - 1, 3, 8, 34),
+        (result) => {
+            expect(result.start).not.toBeNull();
+            expect(result.start.get("year")).toBe(2012);
+            expect(result.start.get("month")).toBe(7);
+            expect(result.start.get("day")).toBe(27);
+
+            expect(result.index).toBe(0);
+            expect(result.text).toBe("yksi viikkoa sitten");
+
+            expect(result.start).toBeDate(new Date(2012, 7 - 1, 27, 8, 34));
+        }
+    );
+});

--- a/test/fi/fi_time_units_casual_relative.test.ts
+++ b/test/fi/fi_time_units_casual_relative.test.ts
@@ -1,0 +1,117 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - Positive time units", () => {
+    testSingleCase(chrono.fi, "seuraavat 2 viikkoa", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono.fi, "seuraavat 2 päivää", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(3);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "seuraavat kaksi vuotta", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2018);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "seuraavat 2 viikkoa 3 päivää", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(18);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "seuraava yksi vuotta", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2017);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(1);
+        expect(result.start.get("hour")).toBe(12);
+    });
+});
+
+test("Test - Negative time units", () => {
+    testSingleCase(chrono.fi, "edelliset 2 viikkoa", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(17);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "viimeiset 2 päivää", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(29);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "kuluneet kaksi viikkoa", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(9);
+        expect(result.start.get("day")).toBe(17);
+        expect(result.start.get("hour")).toBe(12);
+    });
+
+    testSingleCase(chrono.fi, "+2 kuukautta 5 päivää", new Date(2016, 10 - 1, 1, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(12);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("hour")).toBe(12);
+    });
+});
+
+test("Test - Plus '+' sign", () => {
+    testSingleCase(chrono.fi.casual, "+15 minuuttia", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(29);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 29));
+    });
+
+    testSingleCase(chrono.fi.casual, "+15min", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(29);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 29));
+    });
+
+    testSingleCase(chrono.fi.casual, "+1 päivä 2 tuntia", new Date(2012, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("day")).toBe(11);
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start.get("minute")).toBe(14);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 11, 14, 14));
+    });
+});
+
+test("Test - Minus '-' sign", () => {
+    testSingleCase(chrono.fi.casual, "-3vuotta", new Date(2015, 7 - 1, 10, 12, 14), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(10);
+        expect(result.start.get("hour")).toBe(12);
+        expect(result.start.get("minute")).toBe(14);
+
+        expect(result.start).toBeDate(new Date(2012, 7 - 1, 10, 12, 14));
+    });
+});

--- a/test/fi/fi_time_units_within.test.ts
+++ b/test/fi/fi_time_units_within.test.ts
@@ -1,0 +1,74 @@
+import * as chrono from "../../src";
+import { testSingleCase } from "../test_util";
+
+test("Test - 'sisällä' (within) expression", () => {
+    testSingleCase(chrono.fi, "pitää tehdä jotain 5 päivää sisällä", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("5 päivää sisällä");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+
+        expect(result.start).toBeDate(new Date(2012, 8 - 1, 15));
+    });
+
+    testSingleCase(chrono.fi, "5 minuuttia sisällä", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("5 minuuttia sisällä");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono.fi, "1 tuntia sisällä", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("1 tuntia sisällä");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 13, 14));
+    });
+
+    testSingleCase(chrono.fi, "2 viikkoa sisällä", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("2 viikkoa sisällä");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 24, 12, 14));
+    });
+});
+
+test("Test - 'kuluessa' (within/during) expression", () => {
+    testSingleCase(chrono.fi, "5 päivää kuluessa", new Date(2012, 7, 10), (result) => {
+        expect(result.text).toBe("5 päivää kuluessa");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(15);
+    });
+
+    testSingleCase(chrono.fi, "yksi vuotta kuluessa", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("yksi vuotta kuluessa");
+
+        expect(result.start).toBeDate(new Date(2013, 7, 10, 12, 14));
+    });
+});
+
+test("Test - 'päästä' (from now) expression", () => {
+    testSingleCase(chrono.fi, "5 minuuttia päästä", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("5 minuuttia päästä");
+
+        expect(result.start).toBeDate(new Date(2012, 7, 10, 12, 19));
+    });
+
+    testSingleCase(chrono.fi, "3 päivää päästä", new Date(2012, 7, 10, 12, 14), (result) => {
+        expect(result.text).toBe("3 päivää päästä");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(13);
+    });
+
+    testSingleCase(chrono.fi, "2 viikkoa päästä", new Date(2016, 10 - 1, 1), (result) => {
+        expect(result.text).toBe("2 viikkoa päästä");
+        expect(result.start.get("year")).toBe(2016);
+        expect(result.start.get("month")).toBe(10);
+        expect(result.start.get("day")).toBe(15);
+    });
+});

--- a/test/fi/fi_weekday.test.ts
+++ b/test/fi/fi_weekday.test.ts
@@ -1,0 +1,90 @@
+import * as chrono from "../../src/locales/fi";
+import { testSingleCase } from "../test_util";
+
+test("Test - Single Expression", function () {
+    testSingleCase(chrono, "maanantai", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("maanantai");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+    });
+
+    testSingleCase(chrono, "maanantaina", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("maanantaina");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+    });
+});
+
+test("Test - Next/Last Week Expression", function () {
+    testSingleCase(chrono, "ensi maanantai", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("ensi maanantai");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(13);
+        expect(result.start.get("weekday")).toBe(1);
+    });
+
+    testSingleCase(chrono, "viime maanantai", new Date(2012, 7, 9), (result) => {
+        expect(result.index).toBe(0);
+        expect(result.text).toBe("viime maanantai");
+
+        expect(result.start).not.toBeNull();
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(6);
+        expect(result.start.get("weekday")).toBe(1);
+    });
+});
+
+test("Test - Weekday variations", function () {
+    testSingleCase(chrono, "sunnuntai", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(0);
+    });
+
+    testSingleCase(chrono, "tiistai", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(2);
+    });
+
+    testSingleCase(chrono, "keskiviikko", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(3);
+    });
+
+    testSingleCase(chrono, "torstai", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(4);
+    });
+
+    testSingleCase(chrono, "perjantai", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(5);
+    });
+
+    testSingleCase(chrono, "lauantai", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(6);
+    });
+});
+
+test("Test - Weekday abbreviations", function () {
+    testSingleCase(chrono, "ma", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(1);
+    });
+
+    testSingleCase(chrono, "pe", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(5);
+    });
+
+    testSingleCase(chrono, "su", new Date(2012, 7, 9), (result) => {
+        expect(result.start.get("weekday")).toBe(0);
+    });
+});


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                           
  - Add Finnish (fi) locale with 10 parsers and 2 refiners                                                                                                                                                                                                                                 
  - Supports casual dates (tänään, huomenna, eilen), weekdays, month names, time expressions (klo/kello), relative time units, "sitten" (ago), and "sisällä/kuluessa/päästä" (within/from now)                                                                                             
  - 8 test files with ~83 test cases                                                                                                                                                                                                                                                       
   
  Parsers                                                                                                                                                                                                                                                                                  
                                                                  
  - FICasualDateParser — nyt, tänään, huomenna, eilen, ylihuomenna, toissapäivänä, viime yönä                                                                                                                                                                                              
  - FICasualTimeParser — aamulla, päivällä, illalla, yöllä, keskiyöllä
  - FIMonthNameLittleEndianParser — "15. elokuuta 2012"                                                                                                                                                                                                                                    
  - FITimeExpressionParser — "klo 15:00", "kello 8:30"                                                                                                                                                                                                                                     
  - FIWeekdayParser — weekdays with ensi/viime modifiers                                                                                                                                                                                                                                   
  - FITimeUnitCasualRelativeFormatParser — "seuraavat 2 viikkoa", "+15min"                                                                                                                                                                                                                 
  - FITimeUnitAgoFormatParser — "5 päivää sitten"                                                                                                                                                                                                                                          
  - FITimeUnitWithinFormatParser — "5 päivää sisällä/kuluessa/päästä"                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                           
  Test plan                                                       
                                                                                                                                                                                                                                                                                           
  - All 8 Finnish test files pass (23 tests)                      
  - Full test suite passes (518 tests, 114 suites)
