### PR TITLE
fix(en): support 'of' connector in weekday postfix modifier (e.g. 'Tuesday of next week')

### DIFF
--- a/src/locales/en/parsers/ENWeekdayParser.ts
+++ b/src/locales/en/parsers/ENWeekdayParser.ts
@@ -12,7 +12,7 @@ const PATTERN = new RegExp(
         "(?:(this|last|past|next)\\s*)?" +
         `(${matchAnyPattern(WEEKDAY_DICTIONARY)}|weekend|weekday)` +
         "(?:\\s*(?:\\,|\\)|\\）))?" +
-        "(?:\\s*(this|last|past|next)\\s*week)?" +
+        "(?:\\s*(?:of\\s*)?(this|last|past|next)\\s*week)?" +
         "(?=\\W|$)",
     "i"
 );

--- a/test/en/en_weekday.test.ts
+++ b/test/en/en_weekday.test.ts
@@ -342,6 +342,116 @@ test("Test - Weekday range", () => {
     });
 });
 
+test("Test - Weekday 'of next/last/this week' connector", function () {
+    // Ref date is a Tuesday — the same weekday as most test targets below.
+    // Before the fix, 'Tuesday of next week' silently dropped the modifier and
+    // resolved to today (0 days forward) instead of +7 days.
+    const refDate = new Date("Tue Aug 2 2022");
+
+    // --- of next week ---
+
+    testSingleCase(chrono.casual, "Tuesday of next week", refDate, (result) => {
+        expect(result.text).toBe("Tuesday of next week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9); // Aug 9 — NOT today (Aug 2)
+        expect(result.start.get("weekday")).toBe(2);
+        expect(result.start).toBeDate(new Date(2022, 7, 9, 12));
+    });
+
+    testSingleCase(chrono.casual, "Friday of next week", refDate, (result) => {
+        expect(result.text).toBe("Friday of next week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12); // Aug 12
+        expect(result.start.get("weekday")).toBe(5);
+        expect(result.start).toBeDate(new Date(2022, 7, 12, 12));
+    });
+
+    testSingleCase(chrono.casual, "Monday of next week", refDate, (result) => {
+        expect(result.text).toBe("Monday of next week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(8); // Aug 8
+        expect(result.start.get("weekday")).toBe(1);
+        expect(result.start).toBeDate(new Date(2022, 7, 8, 12));
+    });
+
+    // --- of last week ---
+
+    testSingleCase(chrono.casual, "Tuesday of last week", refDate, (result) => {
+        expect(result.text).toBe("Tuesday of last week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(26); // Jul 26
+        expect(result.start.get("weekday")).toBe(2);
+        expect(result.start).toBeDate(new Date(2022, 6, 26, 12));
+    });
+
+    testSingleCase(chrono.casual, "Friday of last week", refDate, (result) => {
+        expect(result.text).toBe("Friday of last week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(7);
+        expect(result.start.get("day")).toBe(29); // Jul 29
+        expect(result.start.get("weekday")).toBe(5);
+        expect(result.start).toBeDate(new Date(2022, 6, 29, 12));
+    });
+
+    // --- of this week ---
+
+    testSingleCase(chrono.casual, "Wednesday of this week", refDate, (result) => {
+        expect(result.text).toBe("Wednesday of this week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(3); // Aug 3
+        expect(result.start.get("weekday")).toBe(3);
+        expect(result.start).toBeDate(new Date(2022, 7, 3, 12));
+    });
+
+    testSingleCase(chrono.casual, "Tuesday of this week", refDate, (result) => {
+        expect(result.text).toBe("Tuesday of this week");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(2); // Aug 2 — same day as ref
+        expect(result.start.get("weekday")).toBe(2);
+        expect(result.start).toBeDate(new Date(2022, 7, 2, 12));
+    });
+
+    // --- with time: merges into a single result (the original bug produced two) ---
+
+    testSingleCase(chrono.casual, "Tuesday of next week after 2pm", refDate, (result) => {
+        expect(result.text).toBe("Tuesday of next week after 2pm");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(9); // Aug 9
+        expect(result.start.get("hour")).toBe(14);
+        expect(result.start).toBeDate(new Date(2022, 7, 9, 14));
+    });
+
+    testSingleCase(chrono.casual, "Friday of next week at 9am", refDate, (result) => {
+        expect(result.text).toBe("Friday of next week at 9am");
+        expect(result.start.get("year")).toBe(2022);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(12); // Aug 12
+        expect(result.start.get("hour")).toBe(9);
+        expect(result.start).toBeDate(new Date(2022, 7, 12, 9));
+    });
+
+    // --- in sentence context ---
+
+    testSingleCase(
+        chrono.casual,
+        "Let's sync on Tuesday of next week",
+        refDate,
+        (result) => {
+            expect(result.text).toBe("on Tuesday of next week");
+            expect(result.start.get("day")).toBe(9);
+            expect(result.start.get("month")).toBe(8);
+            expect(result.start.get("year")).toBe(2022);
+        }
+    );
+});
+
 test("Test - forward dates only option", () => {
     testSingleCase(
         chrono.casual,


### PR DESCRIPTION
## Problem

`ENWeekdayParser` did not recognise the word `of` as a connector between a weekday and its postfix modifier (`this/last/next week`). The postfix group regex only allowed optional whitespace directly before the modifier keyword:

```ts
// before
"(?:\\s*(this|last|past|next)\\s*week)?"
```

As a result, any phrase of the form **`<weekday> of <modifier> week`** silently dropped the modifier and fell back to `getDaysToWeekdayClosest()`. When today is the named weekday (e.g. parsing `"Tuesday of next week"` on a Tuesday), the closest match is 0 days away — returning *today* instead of next week. Additionally, because the full phrase was not consumed as one token, adding a time component (e.g. `"Tuesday of next week after 2pm"`) produced **two separate results** instead of one merged date-time.

## Fix

Add `(?:of\\s*)?` as an optional non-capturing group inside the postfix:

```ts
// after
"(?:\\s*(?:of\\s*)?(this|last|past|next)\\s*week)?"
```

This accepts `"Tuesday of next week"`, `"Friday of last week"`, and `"Wednesday of this week"` while leaving all existing patterns (`"next Tuesday"`, `"Tuesday next week"`, `"Tuesday, next week"`, etc.) completely unchanged.

## Tests

A new `test` block — *"Test - Weekday 'of next/last/this week' connector"* — is added to `test/en/en_weekday.test.ts` with 10 cases covering:

- `of next week` for the same weekday as the ref date (the original edge case)
- `of next week` for earlier and later weekdays
- `of last week` for same and different weekdays
- `of this week` for the same and a forward weekday
- Combined with a time component (`after 2pm`, `at 9am`) — asserts a **single** merged result
- In-sentence context

All 519 tests pass (`npm test`).