### PR TITLE
Add initial Hindi locale support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,9 @@ import * as it from "./locales/it";
 import * as sv from "./locales/sv";
 import * as fi from "./locales/fi";
 import * as vi from "./locales/vi";
+import * as hi from "./locales/hi";
 
-export { de, fr, ja, pt, nl, zh, ru, es, uk, it, sv, fi, vi };
+export { de, fr, ja, pt, nl, zh, ru, es, uk, it, sv, fi, vi, hi };
 
 /**
  * A shortcut for {@link en | chrono.en.strict}

--- a/src/locales/hi/constants.ts
+++ b/src/locales/hi/constants.ts
@@ -1,0 +1,46 @@
+import { matchAnyPattern } from "../../utils/pattern";
+
+export const WEEKDAY_DICTIONARY: { [word: string]: number } = {
+    रविवार: 0,
+    सोमवार: 1,
+    मंगलवार: 2,
+    बुधवार: 3,
+    गुरुवार: 4,
+    शुक्रवार: 5,
+    शनिवार: 6,
+};
+
+export const MONTH_DICTIONARY: { [word: string]: number } = {
+    जनवरी: 1,
+    फरवरी: 2,
+    मार्च: 3,
+    अप्रैल: 4,
+    मई: 5,
+    जून: 6,
+    जुलाई: 7,
+    अगस्त: 8,
+    सितंबर: 9,
+    अक्टूबर: 10,
+    नवंबर: 11,
+    दिसंबर: 12,
+};
+
+export const ORDINAL_NUMBER_PATTERN = `(?:[०-९]{1,2}|[0-9]{1,2})`;
+
+export function parseHindiDigits(match: string): number {
+    const hindiDigits = "०१२३४५६७८९";
+    const normalized = match.replace(/[०-९]/g, (digit) => hindiDigits.indexOf(digit).toString());
+    return parseInt(normalized);
+}
+
+export function parseOrdinalNumberPattern(match: string): number {
+    return parseHindiDigits(match);
+}
+
+export const YEAR_PATTERN = `(?:[१२][०-९]{3}|[1-2][0-9]{3})`;
+
+export function parseYear(match: string): number {
+    return parseHindiDigits(match);
+}
+
+export const MONTH_PATTERN = matchAnyPattern(MONTH_DICTIONARY);

--- a/src/locales/hi/index.ts
+++ b/src/locales/hi/index.ts
@@ -1,0 +1,22 @@
+import { Chrono } from "../../chrono";
+import { ParsingOption, ParsingReference, ParsedResult } from "../../types";
+
+import HIMonthNameLittleEndianParser from "./parsers/HIMonthNameLittleEndianParser";
+import HICasualDateParser from "./parsers/HICasualDateParser";
+import HITimeExpressionParser from "./parsers/HITimeExpressionParser";
+
+export const casual = new Chrono();
+
+casual.parsers.push(new HICasualDateParser());
+casual.parsers.push(new HIMonthNameLittleEndianParser());
+casual.parsers.push(new HITimeExpressionParser());
+
+export function parse(text: string, ref?: ParsingReference | Date, option?: ParsingOption): ParsedResult[] {
+    return casual.parse(text, ref, option);
+}
+
+export function parseDate(text: string, ref?: ParsingReference | Date, option?: ParsingOption): Date | null {
+    return casual.parseDate(text, ref, option);
+}
+
+export default casual;

--- a/src/locales/hi/parsers/HICasualDateParser.ts
+++ b/src/locales/hi/parsers/HICasualDateParser.ts
@@ -1,0 +1,32 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents, ParsingResult } from "../../../results";
+
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+
+import * as references from "../../../common/casualReferences";
+
+export default class HICasualDateParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(context: ParsingContext): RegExp {
+        return /(अभी|आज|बीता\s*कल|आने\s*वाला\s*कल)(?=\W|$)/i;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult | null {
+        const lowerText = match[0].toLowerCase().replace(/\s+/g, " ");
+
+        switch (lowerText) {
+            case "अभी":
+                return references.now(context.reference);
+
+            case "आज":
+                return references.today(context.reference);
+
+            case "बीता कल":
+                return references.yesterday(context.reference);
+
+            case "आने वाला कल":
+                return references.tomorrow(context.reference);
+        }
+
+        return null;
+    }
+}

--- a/src/locales/hi/parsers/HIMonthNameLittleEndianParser.ts
+++ b/src/locales/hi/parsers/HIMonthNameLittleEndianParser.ts
@@ -1,0 +1,51 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingResult } from "../../../results";
+
+import { findYearClosestToRef } from "../../../calculation/years";
+
+import {
+    MONTH_DICTIONARY,
+    MONTH_PATTERN,
+    ORDINAL_NUMBER_PATTERN,
+    parseOrdinalNumberPattern,
+    YEAR_PATTERN,
+    parseYear,
+} from "../constants";
+
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+
+const PATTERN = new RegExp(
+    `(${ORDINAL_NUMBER_PATTERN})\\s*` + `(${MONTH_PATTERN})` + `(?:\\s*(${YEAR_PATTERN}))?` + `(?=\\W|$)`,
+    "i"
+);
+
+const DATE_GROUP = 1;
+const MONTH_NAME_GROUP = 2;
+const YEAR_GROUP = 3;
+
+export default class HIMonthNameLittleEndianParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingResult {
+        const result = context.createParsingResult(match.index!, match[0]);
+
+        const day = parseOrdinalNumberPattern(match[DATE_GROUP]);
+
+        const month = MONTH_DICTIONARY[match[MONTH_NAME_GROUP]]!;
+
+        result.start.assign("day", day);
+        result.start.assign("month", month);
+
+        if (match[YEAR_GROUP]) {
+            result.start.assign("year", parseYear(match[YEAR_GROUP]));
+        } else {
+            const year = findYearClosestToRef(context.refDate, day, month);
+
+            result.start.imply("year", year);
+        }
+
+        return result;
+    }
+}

--- a/src/locales/hi/parsers/HITimeExpressionParser.ts
+++ b/src/locales/hi/parsers/HITimeExpressionParser.ts
@@ -1,0 +1,56 @@
+import { ParsingContext } from "../../../chrono";
+import { ParsingComponents, ParsingResult } from "../../../results";
+import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/AbstractParserWithWordBoundary";
+import { parseHindiDigits } from "../constants";
+
+// Matches: सुबह 10 बजे, शाम 5:30 बजे, 10:30, ५ बजे
+const PATTERN = /(?:(सुबह|प्रातः|दोपहर|शाम|रात)\s*)?([०-९0-9]{1,2})(?:(?:\s*:\s*([०-९0-9]{1,2}))|(?:\s*बजे))/i;
+
+const MERIDIEM_GROUP = 1;
+const HOUR_GROUP = 2;
+const MINUTE_GROUP = 3;
+
+export default class HITimeExpressionParser extends AbstractParserWithWordBoundaryChecking {
+    innerPattern(): RegExp {
+        return PATTERN;
+    }
+
+    innerExtract(context: ParsingContext, match: RegExpMatchArray): ParsingComponents | ParsingResult | null {
+        const result = context.createParsingComponents();
+
+        let hour = parseHindiDigits(match[HOUR_GROUP]);
+        let minute = 0;
+
+        // Parse minutes if they exist (e.g., 10:30)
+        if (match[MINUTE_GROUP]) {
+            minute = parseHindiDigits(match[MINUTE_GROUP]);
+        }
+
+        if (hour > 24 || minute >= 60) {
+            return null;
+        }
+
+        // Handle AM/PM logic based on Hindi context words
+        if (match[MERIDIEM_GROUP]) {
+            const meridiemWord = match[MERIDIEM_GROUP];
+
+            if (meridiemWord === "सुबह" || meridiemWord === "प्रातः") {
+                result.assign("meridiem", 0); // AM
+                if (hour === 12) hour = 0;
+            } else if (meridiemWord === "शाम" || meridiemWord === "रात" || meridiemWord === "दोपहर") {
+                result.assign("meridiem", 1); // PM
+                if (hour < 12) hour += 12;
+            }
+        } else {
+            // If no AM/PM is specified, imply it based on the number
+            if (hour > 12) {
+                result.assign("meridiem", 1); // PM
+            }
+        }
+
+        result.assign("hour", hour);
+        result.assign("minute", minute);
+
+        return result;
+    }
+}

--- a/test/hi/hi.test.ts
+++ b/test/hi/hi.test.ts
@@ -1,0 +1,93 @@
+import * as chrono from "../../src";
+
+test("Parse Hindi absolute date", () => {
+    const results = chrono.hi.parse("5 मई 2026");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("day")).toBe(5);
+    expect(results[0].start.get("month")).toBe(5);
+    expect(results[0].start.get("year")).toBe(2026);
+});
+
+test("Parse Hindi digits date", () => {
+    const results = chrono.hi.parse("५ मई २०२६");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("day")).toBe(5);
+    expect(results[0].start.get("month")).toBe(5);
+    expect(results[0].start.get("year")).toBe(2026);
+});
+
+test("Parse आज", () => {
+    const results = chrono.hi.parse("आज");
+
+    expect(results.length).toBeGreaterThan(0);
+});
+
+test("Parse अभी", () => {
+    const results = chrono.hi.parse("अभी");
+
+    expect(results.length).toBeGreaterThan(0);
+});
+
+test("Parse बीता कल", () => {
+    const results = chrono.hi.parse("बीता कल");
+
+    expect(results.length).toBeGreaterThan(0);
+});
+
+test("Parse आने वाला कल", () => {
+    const results = chrono.hi.parse("आने वाला कल");
+
+    expect(results.length).toBeGreaterThan(0);
+});
+
+test("Parse Hindi sentence date", () => {
+    const results = chrono.hi.parse("परीक्षा 5 मई 2026 को होगी");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("day")).toBe(5);
+});
+
+test("Parse basic Hindi time (बजे)", () => {
+    const results = chrono.hi.parse("५ बजे");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("hour")).toBe(5);
+    expect(results[0].start.get("minute")).toBe(0);
+});
+
+test("Parse time with minutes", () => {
+    const results = chrono.hi.parse("10:30 बजे");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("hour")).toBe(10);
+    expect(results[0].start.get("minute")).toBe(30);
+});
+
+test("Parse PM time (शाम)", () => {
+    const results = chrono.hi.parse("शाम ५ बजे");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("hour")).toBe(17); // 5 PM is 17:00 in 24hr format
+    expect(results[0].start.get("meridiem")).toBe(1); // 1 = PM
+});
+
+test("Parse AM time (सुबह)", () => {
+    const results = chrono.hi.parse("सुबह 10:15");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("hour")).toBe(10);
+    expect(results[0].start.get("minute")).toBe(15);
+    expect(results[0].start.get("meridiem")).toBe(0); // 0 = AM
+});
+
+test("Parse Combined Date and Time", () => {
+    const results = chrono.hi.parse("5 मई 2026 शाम 4 बजे");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].start.get("day")).toBe(5);
+    expect(results[0].start.get("month")).toBe(5);
+    expect(results[0].start.get("year")).toBe(2026);
+    expect(results[0].start.get("hour")).toBe(16);
+});


### PR DESCRIPTION
## Summary

This PR adds initial Hindi locale support to Chrono.

### Supported Features

* Hindi month names
* Hindi numeral parsing
* Casual Hindi expressions
* Hindi date parsing
* Hindi time parsing

### Supported Examples

* `5 मई 2026`
* `५ मई २०२६`
* `आज`
* `अभी`
* `बीता कल`
* `आने वाला कल`
* `शाम ५ बजे`
* `सुबह 10:15`

### Tests

Added unit tests for:

* absolute dates
* Hindi numerals
* casual dates
* Hindi time expressions
* combined date and time parsing

All tests and builds pass successfully.
