### PR TITLE
fix: only include `dist` files into npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "source": "./src",
     "test": "./test"
   },
+  "files": [
+    "dist"
+  ],
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
close #646