### PR TITLE
fix: parse year-before-month-name expressions (e.g. "2024 Aug")

### DIFF
--- a/src/locales/en/parsers/ENMonthNameLittleEndianParser.ts
+++ b/src/locales/en/parsers/ENMonthNameLittleEndianParser.ts
@@ -12,7 +12,7 @@ const PATTERN = new RegExp(
     `(?:on\\s{0,3})?` +
         `(${ORDINAL_NUMBER_PATTERN})` +
         `(?:` +
-            `\\s{0,3}(?:to|\\-|\\–|until|through|till)?\\s{0,3}` +
+            `(?:\\s{0,3}(?:to|\\-|\\–|until|through|till)\\s{0,3}|\\s{1,3})` +
             `(${ORDINAL_NUMBER_PATTERN})` +
         ")?" +
         `(?:-|/|\\s{0,3}(?:of)?\\s{0,3})` +

--- a/src/locales/en/parsers/ENMonthNameParser.ts
+++ b/src/locales/en/parsers/ENMonthNameParser.ts
@@ -7,6 +7,7 @@ import { AbstractParserWithWordBoundaryChecking } from "../../../common/parsers/
 
 const PATTERN = new RegExp(
     `((?:in)\\s*)?` +
+        `(?:([0-9]{4})\\s*[-.\\/]?\\s*)?` +
         `(${matchAnyPattern(MONTH_DICTIONARY)})` +
         `\\s*` +
         `(?:` +
@@ -17,13 +18,16 @@ const PATTERN = new RegExp(
 );
 
 const PREFIX_GROUP = 1;
-const MONTH_NAME_GROUP = 2;
-const YEAR_GROUP = 3;
+const LEADING_YEAR_GROUP = 2;
+const MONTH_NAME_GROUP = 3;
+const YEAR_GROUP = 4;
 
 /**
  * The parser for parsing month name and year.
  * - January, 2012
  * - January 2012
+ * - 2012 January
+ * - 2012-Jan
  * - January
  * (in) Jan
  */
@@ -35,8 +39,13 @@ export default class ENMonthNameParser extends AbstractParserWithWordBoundaryChe
     innerExtract(context: ParsingContext, match: RegExpMatchArray) {
         const monthName = match[MONTH_NAME_GROUP].toLowerCase();
 
-        // skip some unlikely words "jan", "mar", ..
+        // skip some unlikely words "jan", "mar", .. (unless qualified by a year)
         if (match[0].length <= 3 && !FULL_MONTH_NAME_DICTIONARY[monthName]) {
+            return null;
+        }
+
+        // "2012 January" and "January 2012" cannot both supply a year.
+        if (match[LEADING_YEAR_GROUP] && match[YEAR_GROUP]) {
             return null;
         }
 
@@ -50,8 +59,9 @@ export default class ENMonthNameParser extends AbstractParserWithWordBoundaryChe
         const month = MONTH_DICTIONARY[monthName];
         result.start.assign("month", month);
 
-        if (match[YEAR_GROUP]) {
-            const year = parseYear(match[YEAR_GROUP]);
+        const yearMatch = match[LEADING_YEAR_GROUP] || match[YEAR_GROUP];
+        if (yearMatch) {
+            const year = parseYear(yearMatch);
             result.start.assign("year", year);
         } else {
             const year = findYearClosestToRef(context.refDate, 1, month);

--- a/test/en/en_month.test.ts
+++ b/test/en/en_month.test.ts
@@ -89,6 +89,56 @@ test("Test - Month-Year expression", function () {
     });
 });
 
+test("Test - Year-Month expression (year before month)", function () {
+    testSingleCase(chrono, "2024 Aug", new Date(2024, 1 - 1, 15), (result) => {
+        expect(result.text).toBe("2024 Aug");
+
+        expect(result.start.get("year")).toBe(2024);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+        expect(result.start.isCertain("day")).toBe(false);
+
+        expect(result.start).toBeDate(new Date(2024, 8 - 1, 1, 12));
+    });
+
+    testSingleCase(chrono, "2024 August", new Date(2024, 1 - 1, 15), (result) => {
+        expect(result.text).toBe("2024 August");
+
+        expect(result.start.get("year")).toBe(2024);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+    });
+
+    testSingleCase(chrono, "2024-Aug", new Date(2024, 1 - 1, 15), (result) => {
+        expect(result.text).toBe("2024-Aug");
+
+        expect(result.start.get("year")).toBe(2024);
+        expect(result.start.get("month")).toBe(8);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+    });
+
+    testSingleCase(chrono, "2012 January", new Date(2024, 1 - 1, 15), (result) => {
+        expect(result.text).toBe("2012 January");
+
+        expect(result.start.get("year")).toBe(2012);
+        expect(result.start.get("month")).toBe(1);
+        expect(result.start.get("day")).toBe(1);
+
+        expect(result.start.isCertain("year")).toBe(true);
+        expect(result.start.isCertain("month")).toBe(true);
+
+        expect(result.start).toBeDate(new Date(2012, 1 - 1, 1, 12));
+    });
+});
+
 test("Test - Month-Only expression", function () {
     testSingleCase(chrono, "In January", new Date(2020, 11 - 1, 22), (result) => {
         expect(result.text).toContain("January");


### PR DESCRIPTION
Closes #639

## Problem

Parsing `"2024 Aug"` returns **August 2023** instead of August 2024 (the `yyyy MMM` order is a common format). Reproduced with a pinned reference date:

```js
chrono.parse("2024 Aug", new Date(2024, 0, 15));
// => 2023-08-20  ❌  (expected 2024-08-01)
```

Two parsers were involved:

1. **`ENMonthNameParser`** only recognized a *trailing* year (`MMM yyyy`), so for `"2024 Aug"` it matched just `"Aug"`, found no year, and fell back to `findYearClosestToRef` — which, from a January reference, picks the *previous* August.
2. **`ENMonthNameLittleEndianParser`** then matched the contiguous `2024` as a bogus day range: `20` + (empty connector) + `24` → "the 20th–24th of August". Because both results spanned the same text, overlap resolution kept this wrong one.

The reverse order (`"Aug 2024"`) already worked, which is why this looked inconsistent.

## Fix

- **`ENMonthNameParser`**: recognize an optional leading 4-digit year, so `"2024 Aug"`, `"2024-Aug"`, `"2024.Aug"`, and `"2012 January"` parse as a single result with a *certain* year. A 4-digit year is required (not 2-digit) to avoid clashing with the day-month format (`"09 Aug"` must stay "9 August"). A guard rejects supplying a year on both sides (`"2012 January 2013"`).
- **`ENMonthNameLittleEndianParser`**: require a real separator between the two day numbers of a range, so a contiguous 4-digit number is no longer split into a spurious `day-to-day` range. Existing ranges are unaffected: `"10 - 22 August"`, `"10 to 22 August"`, `"10-22 August"`, and space-only `"10 22 August"` all still parse as ranges.

## Tests

Added a `Year-Month expression (year before month)` block in `test/en/en_month.test.ts` covering `"2024 Aug"`, `"2024 August"`, `"2024-Aug"`, and `"2012 January"` with pinned reference dates. These **fail** on `master` (`Expected: 2024, Received: 2023`) and **pass** with the fix.

Full suite green: 615 passed.