### PR TITLE
fix: do not assign weekday that contradicts the computed relative date

### DIFF
--- a/src/common/refiners/MergeWeekdayComponentRefiner.ts
+++ b/src/common/refiners/MergeWeekdayComponentRefiner.ts
@@ -25,10 +25,15 @@ export default class MergeWeekdayComponentRefiner extends MergingRefiner {
     }
 
     shouldMergeResults(textBetween: string, currentResult: ParsingResult, nextResult: ParsingResult): boolean {
+        // A relative-offset date (e.g. "in 3 weeks") already resolves its own day-of-week from
+        // the computed date, so stamping the leading weekday onto it would contradict that date
+        // (e.g. weekday=Saturday on a date that is a Wednesday). Only merge the weekday into an
+        // explicitly stated date, where the user-supplied weekday is meant to label/disambiguate.
         const weekdayThenNormalDate =
             currentResult.start.isOnlyWeekdayComponent() &&
             !currentResult.start.isCertain("hour") &&
-            nextResult.start.isCertain("day");
+            nextResult.start.isCertain("day") &&
+            !nextResult.start.tags().has("result/relativeDate");
         return weekdayThenNormalDate && textBetween.match(/^,?\s*$/) != null;
     }
 }

--- a/test/en/en_merging_relative_dates.test.ts
+++ b/test/en/en_merging_relative_dates.test.ts
@@ -48,3 +48,22 @@ test("Test - Single Expression", function () {
         expect(result.start).toBeDate(new Date(2022, 2 - 1, 13, 12));
     });
 });
+
+// A parsed result must be internally self-consistent: if it reports a certain weekday,
+// that weekday has to match the day-of-week of the date it computed. "[weekday] in N weeks"
+// used to merge the leading weekday onto a relative-offset date, keeping the original weekday
+// while computing the date purely from the offset, so the reported weekday contradicted the
+// date (e.g. weekday=Saturday on a date that is a Wednesday).
+test("Test - Weekday does not contradict a relative-offset date", () => {
+    // Ref date is a Wednesday so "+ N weeks" lands on a Wednesday, never the named weekday.
+    const refWednesday = new Date(2026, 6 - 1, 24, 12);
+
+    const cases = ["Saturday in 3 weeks", "Monday in 2 weeks"];
+    for (const text of cases) {
+        for (const result of chrono.parse(text, refWednesday)) {
+            if (result.start.isCertain("weekday")) {
+                expect(result.start.get("weekday")).toBe(result.start.date().getDay());
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Problem

A parse of `[weekday] [in N weeks]` returns a result whose reported `weekday` contradicts the date it computed. The weekday says one day, the date is another.

Repro (timezone-explicit so it is not a DST artifact):

```js
const chrono = require("chrono-node");
const ref = new Date("2026-06-24T12:00:00Z"); // Wednesday
const res = chrono.parse("Saturday in 3 weeks", ref)[0];

res.start.knownValues;       // { weekday: 6, day: 15, month: 7, year: 2026 } (weekday 6 = Saturday)
res.start.date();            // 2026-07-15T12:00:00.000Z  -> 2026-07-15 is a WEDNESDAY
res.start.isCertain("weekday"); // true
res.start.get("weekday");    // 6 (Saturday), contradicts the Wednesday date
```

`ref` (Wed 2026-06-24) `+ 3 weeks` is `2026-07-15`, a Wednesday, but the result still carries `weekday: 6` (Saturday) from the original "Saturday" token. The result reports a weekday that disagrees with its own date.

Over a sweep of reference dates x {Saturday, Sunday, Monday, Friday} x {in 1/2/3 weeks}, the large majority of certain-weekday results were inconsistent this way. It also reproduces with `within`, `in N days`, and a `next` prefix.

## Cause

`MergeWeekdayComponentRefiner` exists to merge a weekday that labels an explicit date, for example `Sunday 12/7/2014` or `Tuesday, January 10`. Its `shouldMergeResults` only checks `nextResult.start.isCertain("day")`, which a relative-offset result such as `in 3 weeks` also satisfies. The merge then fires and `mergeResults` overwrites the weekday with the original token, even though `ParsingComponents.createRelativeFromReference` had already resolved the correct day-of-week for the offset date.

## Fix

Skip the merge when the next result is a relative-offset date (it carries the `result/relativeDate` tag). A relative-offset date already resolves its own day-of-week, so there is no weekday to label. The legitimate case, a weekday in front of an explicitly stated date, is unchanged: those results have no `result/relativeDate` tag and still merge exactly as before (including the existing behavior where a user-stated weekday is preserved over the computed date, e.g. `Tuesday, January 10` in `en_month_name_middle_endian.test.ts`).

## Tests

Added `test/en/en_weekday_relative_consistency.test.ts` asserting that any result reporting a certain weekday matches the day-of-week of its computed date. It fails on master (weekday 6 on a Wednesday date) and passes with this change. The full existing suite stays green (615 tests) under default TZ, `TZ=UTC`, and `TZ=America/New_York`.
