### PR TITLE
fix: keep casual-time meridiem in de/fr/it/fi when merged with an explicit time

### DIFF
--- a/src/locales/de/parsers/DECasualTimeParser.ts
+++ b/src/locales/de/parsers/DECasualTimeParser.ts
@@ -24,6 +24,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/morning");
                 break;
 
             case "vormittag":
@@ -31,6 +32,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/morning");
                 break;
 
             case "mittag":
@@ -39,6 +41,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/noon");
                 break;
 
             case "nachmittag":
@@ -46,6 +49,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "abend":
@@ -53,6 +57,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/evening");
                 break;
 
             case "nacht":
@@ -60,6 +65,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/evening");
                 break;
 
             case "mitternacht":
@@ -71,6 +77,7 @@ export default class DECasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/midnight");
                 break;
         }
         return component;

--- a/src/locales/fi/parsers/FICasualTimeParser.ts
+++ b/src/locales/fi/parsers/FICasualTimeParser.ts
@@ -25,6 +25,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/morning");
                 break;
 
             case "aamupäivällä":
@@ -32,6 +33,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/morning");
                 break;
 
             case "päivällä":
@@ -39,6 +41,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/noon");
                 break;
 
             case "iltapäivällä":
@@ -46,6 +49,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "illalla":
@@ -53,6 +57,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/evening");
                 break;
 
             case "yöllä":
@@ -60,6 +65,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/evening");
                 break;
 
             case "keskiyöllä":
@@ -71,6 +77,7 @@ export default class FICasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("minute", 0);
                 component.imply("second", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/midnight");
                 break;
         }
         return component;

--- a/src/locales/fr/parsers/FRCasualTimeParser.ts
+++ b/src/locales/fr/parsers/FRCasualTimeParser.ts
@@ -18,29 +18,34 @@ export default class FRCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 14);
                 component.imply("minute", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "soir":
                 component.imply("hour", 18);
                 component.imply("minute", 0);
                 component.imply("meridiem", Meridiem.PM);
+                component.addTag("casualReference/evening");
                 break;
 
             case "matin":
                 component.imply("hour", 8);
                 component.imply("minute", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/morning");
                 break;
 
             case "a midi":
                 component.imply("hour", 12);
                 component.imply("minute", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/noon");
                 break;
 
             case "à minuit":
                 component.imply("hour", 0);
                 component.imply("meridiem", Meridiem.AM);
+                component.addTag("casualReference/midnight");
                 break;
         }
 

--- a/src/locales/it/parsers/ITCasualTimeParser.ts
+++ b/src/locales/it/parsers/ITCasualTimeParser.ts
@@ -18,12 +18,14 @@ export default class ITCasualTimeParser extends AbstractParserWithWordBoundaryCh
             case "pomeriggio":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 15);
+                component.addTag("casualReference/afternoon");
                 break;
 
             case "sera":
             case "notte":
                 component.imply("meridiem", Meridiem.PM);
                 component.imply("hour", 20);
+                component.addTag("casualReference/evening");
                 break;
 
             case "mezzanotte":
@@ -34,16 +36,19 @@ export default class ITCasualTimeParser extends AbstractParserWithWordBoundaryCh
                 component.imply("hour", 0);
                 component.imply("minute", 0);
                 component.imply("second", 0);
+                component.addTag("casualReference/midnight");
                 break;
 
             case "mattina":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 6);
+                component.addTag("casualReference/morning");
                 break;
 
             case "mezzogiorno":
                 component.imply("meridiem", Meridiem.AM);
                 component.imply("hour", 12);
+                component.addTag("casualReference/noon");
                 break;
         }
 

--- a/test/de/de_casual.test.ts
+++ b/test/de/de_casual.test.ts
@@ -320,3 +320,17 @@ test("Test - Random negative text", function () {
 
     testUnexpectedResult(chrono.de, "ljetztlich");
 });
+
+test("Test - Casual time keeps its meridiem when merged with an explicit time", () => {
+    testSingleCase(chrono.de, "nachmittag um 5", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+
+    testSingleCase(chrono.de, "abend um 5", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+});

--- a/test/fi/fi_casual.test.ts
+++ b/test/fi/fi_casual.test.ts
@@ -83,3 +83,17 @@ test("Test - Combined Expression", function () {
         expect(result.start.get("hour")).toBe(0);
     });
 });
+
+test("Test - Casual time keeps its meridiem when merged with an explicit time", () => {
+    testSingleCase(chrono, "iltapäivällä klo 5", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+
+    testSingleCase(chrono, "illalla klo 8", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+});

--- a/test/fr/fr_casual.test.ts
+++ b/test/fr/fr_casual.test.ts
@@ -298,3 +298,17 @@ test("Test - Combined Expression", function () {
 //     expect(results.length).toBe(0);
 //
 // });
+
+test("Test - Casual time keeps its meridiem when merged with an explicit time", () => {
+    testSingleCase(chrono.fr, "après-midi à 5", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+
+    testSingleCase(chrono.fr, "soir à 8", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+});

--- a/test/it/it_casual.test.ts
+++ b/test/it/it_casual.test.ts
@@ -42,3 +42,17 @@ test("Test - Single Expression", () => {
         expect(result.start).toBeDate(new Date(2012, 7, 11, 17, 10));
     });
 });
+
+test("Test - Casual time keeps its meridiem when merged with an explicit time", () => {
+    testSingleCase(chrono.it, "pomeriggio alle 5", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(17);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+
+    testSingleCase(chrono.it, "sera alle 8", new Date(2016, 7, 10, 12), (result, text) => {
+        expect(result.text).toBe(text);
+        expect(result.start.get("hour")).toBe(20);
+        expect(result.start.get("meridiem")).toBe(1);
+    });
+});


### PR DESCRIPTION
When a date part and a time part are merged, `mergeDateTimeComponent` decides whether the explicit time's meridiem may override the date part's meridiem. Since #637 it keeps the date part's meridiem only when that meridiem is certain or carries a `casualReference/` tag:

```ts
const dateHasMeaningfulMeridiem =
    dateComponent.get("meridiem") != null &&
    (dateComponent.isCertain("meridiem") ||
        Array.from(dateComponent.tags()).some((t) => t.startsWith("casualReference/")));
```

#637 added that tag to the inline casual-time parsers for `es`, `nl` and `pt`, and the shared `common/casualReferences` helpers already carry it (which covers `en`). The inline casual-time parsers for `de`, `fr`, `it` and `fi` were not updated, so their casual references only imply a meridiem without the tag. When such a reference is merged with a bare time, the time's implied AM wins and the afternoon/evening hint is dropped:

- `de`: "nachmittag um 5" gives 05:00 instead of 17:00
- `fr`: "après-midi à 5" gives 05:00 instead of 17:00
- `it`: "pomeriggio alle 5" gives 05:00 instead of 17:00
- `fi`: "iltapäivällä klo 5" gives 05:00 instead of 17:00

This adds the matching `casualReference/...` tag to each casual branch in those four parsers, the same way #637 did for the other locales, plus a regression test per locale. `en`/`es`/`nl`/`pt` already parse these correctly.

The full suite passes (618 tests). Reverting just the parser changes makes the four new tests fail with `Expected: 17, Received: 5`.
