### PR TITLE
fix(uk): compile forwardDate "within" pattern with the unicode flag

### DIFF
--- a/src/locales/uk/parsers/UKTimeUnitWithinFormatParser.ts
+++ b/src/locales/uk/parsers/UKTimeUnitWithinFormatParser.ts
@@ -12,7 +12,7 @@ export default class UKTimeUnitWithinFormatParser extends AbstractParserWithWord
 
     innerPattern(context: ParsingContext): RegExp {
         return context.option.forwardDate
-            ? new RegExp(PATTERN, "i")
+            ? new RegExp(PATTERN, REGEX_PARTS.flags)
             : new RegExp(`(?:протягом|на протязі|протягом|упродовж|впродовж)\\s*${PATTERN}`, REGEX_PARTS.flags);
     }
 

--- a/test/uk/uk_time_units_within.test.ts
+++ b/test/uk/uk_time_units_within.test.ts
@@ -1,5 +1,5 @@
 import * as chrono from "../../src";
-import { testSingleCase } from "../test_util";
+import { testSingleCase, testUnexpectedResult } from "../test_util";
 
 test("Test - The normal within expression", () => {
     testSingleCase(chrono.uk, "буде зроблено протягом хвилини", new Date(2012, 7, 10), (result) => {
@@ -13,4 +13,11 @@ test("Test - The normal within expression", () => {
         expect(result.text).toBe("на протязі 2 годин");
         expect(result.start).toBeDate(new Date(2012, 7, 10, 2));
     });
+});
+
+test("Test - Within expression respects the word boundary", () => {
+    // The forwardDate branch builds a bare time-unit pattern whose right boundary uses the
+    // \p{L}\p{N} escapes, so a unit glued to a following letter must not match. "годин" (hours)
+    // is a prefix of "годинників" (watches), so this sentence must not parse as "5 hours".
+    testUnexpectedResult(chrono.uk, "купив 5 годинників", new Date(2012, 7, 10), { forwardDate: true });
 });


### PR DESCRIPTION
`UKTimeUnitWithinFormatParser` builds its `forwardDate` branch with `new RegExp(PATTERN, "i")`, dropping the `u` flag.

`PATTERN` ends with `REGEX_PARTS.rightBoundary` (`(?=[^\p{L}\p{N}_]|$)`), and `patternLeftBoundary()` returns `REGEX_PARTS.leftBoundary` (`([^\p{L}\p{N}_]|^)`), so the regex `AbstractParserWithWordBoundaryChecking.pattern()` compiles for this parser contains `\p{L}`/`\p{N}`. Without the `u` flag those are read as identity escapes (`p`, `{`, `L`, `}`, ...), not Unicode letter/number classes, so the word boundary stops rejecting Cyrillic letters.

The non-forward branch right below it already uses `REGEX_PARTS.flags` (`"iu"`), and both branches of the Russian `RUTimeUnitWithinFormatParser` use `REGEX_PARTS.flags`, so the `"i"` here looks like a copy that was left behind.

In practice, with `forwardDate: true` a unit that is only a prefix of a longer word still matches. `годин` (hours) is a prefix of `годинників` (watches), so `купив 5 годинників` ("bought 5 watches") is parsed as `5 годин` ("5 hours").

The change uses `REGEX_PARTS.flags` in the forward branch, the same as the sibling branch and the `ru` parser. I added a regression to `test/uk/uk_time_units_within.test.ts`; `test/uk` and `test/ru` are green (86 tests).
